### PR TITLE
Specify dependencies for the Python script inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,46 @@ The framework consists of:
 
 ### Development Environment
 
-Using Nix, use `nix develop` obtain a shell that provides the necessary dependencies, which are:
+The arena tool (`lka.py`) has a number of dependencies, which include:
 
-* `python3` with dependencies (`jinja2`, `pyyaml`, `jsonschema`, `markdown`)
-* GNU `time`
 * `elan` to build Lean code
 * `rustc` and `cargo` to build Rust code
+* GNU `time`
+
+as well as a Python installation with a number of Python dependencies.
+
+Using Nix, you can use `nix develop` to obtain a shell that provides all of the necessary dependencies.
 
 ### Running Locally
+
+#### Via `uv`
+
+After [installing `uv`](https://docs.astral.sh/uv/#installation) and the 3 non-Python dependencies above, you can use:
+
+```bash
+# Build all tests
+uv run lka.py build-test
+
+# Build all checkers
+uv run lka.py build-checker
+
+# Run all checkers on all tests
+uv run lka.py run
+
+# Generate the website
+uv run lka.py build-site
+
+# View results
+python3 -m http.server 8880 --directory _out
+```
+
+where all commands will automatically install any requisite Python dependencies.
+
+The `build-test`, `build-checker` and `run` commands can be instructed to build or run specific checkers or tests only.
+
+#### Via a Virtual Environment With Python Dependencies Installed
+
+If you have installed the Python dependencies yourself, or via `nix`:
 
 ```bash
 # Build all tests
@@ -53,8 +85,6 @@ Using Nix, use `nix develop` obtain a shell that provides the necessary dependen
 # View results
 python3 -m http.server 8880 --directory _out
 ```
-
-The `build-test`, `build-checker` and `run` commands can be instructed to build or run specific checkers or tests only.
 
 ## Contributing
 

--- a/lka.py
+++ b/lka.py
@@ -6,7 +6,6 @@ import datetime
 import fnmatch
 import json
 import os
-import resource
 import shutil
 import subprocess
 import sys
@@ -155,7 +154,7 @@ def extract_ndjson_metadata(ndjson_file: Path) -> dict:
                             metadata["lean_version"] = lean_info["version"]
                         if "githash" in lean_info:
                             metadata["lean_githash"] = lean_info["githash"]
-    except Exception as e:
+    except Exception:
         # Silently ignore metadata extraction errors
         pass
 
@@ -290,7 +289,7 @@ def measure_perf_with_fallback(
             try:
                 os.unlink(perf_tmp_path)
                 os.unlink(time_tmp_path)
-            except:
+            except Exception:
                 pass
 
             # Extract metrics with fallbacks
@@ -688,9 +687,9 @@ def setup_source_directory(
         dest_toolchain = src_dir / "lean-toolchain"
         if tests_toolchain.exists():
             shutil.copy(tests_toolchain, dest_toolchain)
-            print(f"  Copied lean-toolchain from tests/ to src directory")
+            print("  Copied lean-toolchain from tests/ to src directory")
         else:
-            print(f"  Warning: No lean-toolchain file found in tests/ directory")
+            print("  Warning: No lean-toolchain file found in tests/ directory")
 
         # Create a trivial lakefile in the src directory
         lakefile_content = '''name = "test"
@@ -700,7 +699,7 @@ name = "Test"'''
         lakefile_path = src_dir / "lakefile.toml"
         with open(lakefile_path, "w") as f:
             f.write(lakefile_content)
-        print(f"  Created trivial lakefile")
+        print("  Created trivial lakefile")
 
         return src_dir
 
@@ -824,7 +823,7 @@ def create_test(test: dict, output_dir: Path) -> bool:
 
         # Export using lean4export
         if export_decls and not isinstance(export_decls, list):
-            print(f"  Error: export-decls must be a list of strings")
+            print("  Error: export-decls must be a list of strings")
             return False
 
         if export_decls:
@@ -1443,9 +1442,9 @@ def get_build_metadata() -> dict:
                         elif remote_url.startswith("https://"):
                             repo_path = remote_url.replace("https://github.com/", "").replace(".git", "")
                             metadata["github_url"] = f"https://github.com/{repo_path}/commit/{git_revision}"
-            except:
+            except Exception:
                 pass
-    except:
+    except Exception:
         pass
 
     # Get GitHub Action info from environment variables
@@ -1523,7 +1522,6 @@ def create_test_tarball(tests: list, output_dir: Path) -> dict:
     Returns dict with tarball_size (in bytes), good_count, and bad_count.
     """
     import tarfile
-    import os
 
     tarball_path = output_dir / "lean-arena-tests.tar.gz"
 

--- a/lka.py
+++ b/lka.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+#     "jinja2>=3.1.6",
+#     "jsonschema>=4.26.0",
+#     "markdown>=3.10",
+#     "pyyaml>=6.0.3",
+# ]
+# ///
 """Lean Kernel Arena - Tool for managing Lean kernel tests and checkers."""
 
 import argparse


### PR DESCRIPTION
(https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata)

In particular this makes e.g. `uv run lka.py ...` work with no dependency hunting.

(I didn't update the README snippets saying to do that, though I'm happy to do so if needed, and there's also a few trivial style tweaks here in a separate commit.