### PR TITLE
Add tutorial tests for literal nats and strs.

### DIFF
--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -16,6 +16,21 @@ good_def arrowType : Type := Prop → Prop
 /-- Dependent type (forall) -/
 good_def dependentType : Prop := ∀ (p: Prop), p
 
+/-- String -/
+good_def someString : String := "Hello!"
+
+/-- Non-ASCII String -/
+good_def someNonASCIIString : String := "🎉 Goals Accomplished"
+
+/-- Not a String -/
+bad_def notAString : String := Prop
+
+/-- Nat -/
+good_def importantNumber : Nat := 37
+
+/-- Not a Nat -/
+bad_def notANat : Nat := Nat
+
 /-- Lambda expression -/
 good_def simpleLambda : Type → Type → Type := fun x y => x
 


### PR DESCRIPTION
Regardless of how you want to handle #4 these seem like they might be agreeable.

FWIW in terms of #4, these get me coverage for an additional:

```
    LitStr,
    LitNat,
    Proj,
    Let,
    RecRule,
    Recursor,
    UniverseMax,
    Constructor,
    InductiveSkeleton,
```

leaving only axiom. opaque and quotients (and strict implicit binders) uncovered.