### PR TITLE
CI: upload self-contained report as non-zipped artifact

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -109,21 +109,21 @@ jobs:
         run: ./lka.py build-site
         shell: 'nix develop -c bash -euxo pipefail {0}'
       
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '_out'
+
       - name: Generate self-contained report
-        run: monolith _out/index.html -o _out/report.html -i -F -e -M -q
+        run: monolith _out/index.html -o /tmp/report.html -i -F -e -M -q
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Upload report
         uses: actions/upload-artifact@v7
         with:
           name: report.html
-          path: '_out/report.html'
+          path: '/tmp/report.html'
           archive: false
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: '_out'
 
       - name: Deploy to GitHub Pages
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -109,11 +109,22 @@ jobs:
         run: ./lka.py build-site
         shell: 'nix develop -c bash -euxo pipefail {0}'
       
+      - name: Generate self-contained report
+        run: monolith _out/index.html -o _out/report.html -i -F -e -M -q
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        with:
+          name: report.html
+          path: '_out/report.html'
+          archive: false
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: '_out'
-      
+
       - name: Deploy to GitHub Pages
         if: github.event_name == 'workflow_dispatch'
         id: deployment

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767480499,
-        "narHash": "sha256-8IQQUorUGiSmFaPnLSo2+T+rjHtiNWc+OAzeHck7N48=",
+        "lastModified": 1773068389,
+        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30a3c519afcf3f99e2c6df3b359aec5692054d92",
+        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           pkg-config
           just
           pypy
+          monolith
         ];
       };
     };


### PR DESCRIPTION
## Summary
- Use `monolith` to inline CSS into `index.html`, producing a self-contained `report.html` that can be viewed directly when downloaded from CI artifacts
- Upload `report.html` as a non-zipped artifact using `upload-artifact@v7` with `archive: false` ([changelog](https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/))
- Add `monolith` to the nix dev shell

## Test plan
- [ ] Verify CI runs successfully
- [ ] Download `report.html` artifact and confirm it renders correctly in a browser without network access

🤖 Generated with [Claude Code](https://claude.com/claude-code)