### PR TITLE
Bump nanobruijn to 96b2a2d

### DIFF
--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -18,7 +18,7 @@ description: |
   modifications from the original nanoda_lib were written by Claude (Anthropic).
 url: https://github.com/nomeata/nanobruijn
 ref: master
-rev: 083d423d06f71098f1212f637165900810d31133
+rev: 96b2a2d9ed9ee2183c179ba46cf6948b36df6cf2
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
## Summary
- Bump nanobruijn rev to 96b2a2d (spec_app optimizations)
- Full Mathlib: 1317s (1.35x nanoda), 0 errors, 0 timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)