### PR TITLE
chore: bump nanoda version to 0.4.8-beta

### DIFF
--- a/checkers/nanoda.yaml
+++ b/checkers/nanoda.yaml
@@ -17,7 +17,7 @@ description: |
   of failure, so they are all repoted as “rejected”.
 url: https://github.com/ammkrn/nanoda_lib
 ref: master
-rev: 68d5ca9db226849b41a6fff59d796ff19d0a8840
+rev: 6d2f03717af89dde5b8906bb957a6a50eeecbb94
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
Includes a significant performance improvement by github user @eisbaw.