### PR TITLE
bump nanobruijn to 892be94

### DIFF
--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -18,7 +18,7 @@ description: |
   modifications from the original nanoda_lib were written by Claude (Anthropic).
 url: https://github.com/nomeata/nanobruijn
 ref: master
-rev: 96b2a2d9ed9ee2183c179ba46cf6948b36df6cf2
+rev: 892be94c9c6aec798ebd9b3bc6804dab1758bb51
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
## Summary
- Port upstream nanoda Ptr bit-31 encoding (4-byte aligned Ptr replacing 5-byte repr(packed), +12% reported upstream)
- infer_app: preserve lazy Shift wrappers for shift-peel cache reuse (closed Mathlib gap from 37% to 8% vs nanoda)
- ReusableDag support for nanoda TC path (fair comparison baseline)
- Fix truncating casts from upstream nanoda

🤖 Generated with [Claude Code](https://claude.com/claude-code)