### PR TITLE
fix: use dynamic root_path in test pages for nested test names

### DIFF
--- a/lka.py
+++ b/lka.py
@@ -1844,11 +1844,17 @@ def cmd_build_site(args: argparse.Namespace) -> int:
 
                     test_results.append(result)
 
+            # Compute relative path to site root from test/name/index.html
+            # e.g. "app-lam" -> "../../", "perf/app-lam" -> "../../../"
+            depth = test["name"].count("/") + 2  # +2 for "test/" and trailing "/"
+            root_path = "../" * depth
+
             test_data = {
                 "test": test,
                 "test_links": test_links,
                 "test_description": render_markdown(test.get("description", "")),
                 "results": test_results,
+                "root_path": root_path,
                 "format_duration": format_duration,
                 "format_memory": format_memory,
                 "format_instructions": format_instructions,

--- a/templates/test.html
+++ b/templates/test.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% from "macros.html" import detail_styles, result_status_cell, perf_cells, perf_header %}
 
-{% block static_path %}../../{% endblock %}
+{% block static_path %}{{ root_path }}{% endblock %}
 
 {% block title %}{{ test.name }} - Lean Kernel Arena{% endblock %}
 
-{% block h1 %}<a href="../../">Lean Kernel Arena</a> / {{ test.name }}
+{% block h1 %}<a href="{{ root_path }}">Lean Kernel Arena</a> / {{ test.name }}
 {% endblock %}
 
 {% block style %}
@@ -59,7 +59,7 @@
         <tbody>
             {% for result in results %}
             <tr>
-                <td><a href="../../checker/{{ result.checker }}/#test-{{ test.name }}">{{ result.checker }}</a></td>
+                <td><a href="{{ root_path }}checker/{{ result.checker }}/#test-{{ test.name }}">{{ result.checker }}</a></td>
                 {{ result_status_cell(test.outcome, result.status) }}
                 {{ perf_cells(result, test.outcome, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time) }}
             </tr>


### PR DESCRIPTION
## Summary
- Test pages at `test/perf/app-lam/` need 3 levels of `../` to reach the site root, not the hardcoded 2
- Compute `root_path` from the test name depth and pass it to the template
- Fixes broken CSS/navigation links for tests in subdirectories (introduced by recursive YAML loading in #21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)