### PR TITLE
Bump nanobruijn to e6e112a (OSNF)

### DIFF
--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -20,7 +20,7 @@ description: |
   modifications from the original nanoda_lib were written by Claude (Anthropic).
 url: https://github.com/nomeata/nanobruijn
 ref: master
-rev: e6e112a50e74a5be8eec43d5b0bcf4b969c24b86
+rev: e6e112a86e0cd499f9050afeeaa3bd2745cadf54
 build: |
   cargo build --release
   cat > config.json <<__END__

--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -13,12 +13,14 @@ description: |
     and are pushed inward during normalization.
   - **Shift-homomorphic caching**: whnf cache keys are shift-invariant, so a
     single cache entry serves all shifted variants of an expression.
+  - **Parse-time normalization**: expressions that differ only by a uniform
+    shift of free variable indices share a common core in the DAG.
 
   This is an experimental checker, not intended for production use. All code
   modifications from the original nanoda_lib were written by Claude (Anthropic).
 url: https://github.com/nomeata/nanobruijn
 ref: master
-rev: 892be94c9c6aec798ebd9b3bc6804dab1758bb51
+rev: e6e112a50e74a5be8eec43d5b0bcf4b969c24b86
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
## Summary
- Bump nanobruijn to e6e112a which adds OSNF (Outermost-Shift Normal Form) parse-time normalization
- Expressions with `fvar_lb > 0` are stored as `Shift(fvar_lb, core)` where `core` has `fvar_lb = 0`
- Shift-equivalent expressions share cores in the DAG, improving TC cache hit rates across binder depths
- A/B/A test on full Mathlib: **-7% user time** (1175s → 1095s), +18% RSS (7.9GB → 9.3GB)

## Test plan
- [x] Passes Init (54K declarations)
- [x] Passes full Mathlib (630K declarations, 0 errors)
- [ ] Arena CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)