### PR TITLE
Bump nanobruijn to a5c4248 (fix OSNF stats overflow)

### DIFF
--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -20,7 +20,7 @@ description: |
   modifications from the original nanoda_lib were written by Claude (Anthropic).
 url: https://github.com/nomeata/nanobruijn
 ref: master
-rev: e6e112a86e0cd499f9050afeeaa3bd2745cadf54
+rev: a5c42486a12b8a03f2fe80147d68998faa680b76
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
## Summary
- Fix subtraction overflow in OSNF stats line when DAG grows beyond parser entries + osnf_count (e.g. on app-lam test)
- No semantic changes to OSNF logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)