### PR TITLE
Update official checker set

### DIFF
--- a/checkers/lean-pr-10565.yaml
+++ b/checkers/lean-pr-10565.yaml
@@ -1,9 +1,0 @@
-version: "2026-01-10"
-description: |
-  The official Lean 4 kernel checker implementation, with the changes from
-  [PR #10565](https://github.com/leanprover/lean4/pull/10565).
-dir: official
-build: |
-  echo leanprover/lean4-pr-releases:pr-release-10565-5e14d49 > lean-toolchain
-  lake build
-run: .lake/build/bin/kernel "$IN"

--- a/checkers/official-nightly.yaml
+++ b/checkers/official-nightly.yaml
@@ -1,8 +1,8 @@
-version: "2026-03-07"
+version: "2026-04-11"
 description: |
   The official Lean 4 kernel checker implementation, nightly release.
 dir: official
 build: |
-  echo leanprover/lean4:nightly-2026-03-07 > lean-toolchain
+  echo leanprover/lean4:nightly-2026-04-11 > lean-toolchain
   lake build
 run: .lake/build/bin/kernel "$IN"

--- a/checkers/official-v4.28.0.yaml
+++ b/checkers/official-v4.28.0.yaml
@@ -1,0 +1,8 @@
+version: "4.28.0"
+description: |
+  The official Lean 4 kernel checker implementation (v4.28.0).
+dir: official
+build: |
+  echo leanprover/lean4:v4.28.0 > lean-toolchain
+  lake build
+run: .lake/build/bin/kernel "$IN"

--- a/checkers/official.yaml
+++ b/checkers/official.yaml
@@ -1,11 +1,11 @@
-version: "4.28.0-rc1"
+version: "4.29.0"
 description: |
   The official Lean 4 kernel checker implementation.
-  
+
   This is the reference implementation from the Lean 4 repository,
   wrapped in a program that reads the exported proofs and replays them in the kernel.
 dir: official
 build: |
-  echo leanprover/lean4:v4.28.0-rc1 > lean-toolchain
+  echo leanprover/lean4:v4.29.0 > lean-toolchain
   lake build
 run: .lake/build/bin/kernel "$IN"


### PR DESCRIPTION
## Summary
- Bump official checker to v4.29.0 (was v4.28.0-rc1)
- Add official-v4.28.0 checker for the v4.28.0 release
- Bump official-nightly to 2026-04-11 (was 2026-03-07)
- Remove lean-pr-10565 checker
- Add lean4lean v4.29.0 support (rev 9e068dc)
- Update tests/lean-toolchain to v4.29.0
- Update mathlib test to use v4.29.0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)