### PR TITLE
Bump to v4.29.0: lean4lean, tests, mathlib

### DIFF
--- a/checkers/lean4lean/lean4lean-wrapper.py
+++ b/checkers/lean4lean/lean4lean-wrapper.py
@@ -15,8 +15,7 @@ TOOLCHAIN_TO_TAG = {
     "4.27.0-rc1": ("arena/v4.27.0-rc1","481d2a0"),
     "4.28.0-nightly-2026-01-19": ("arena/v4.27.0-rc1","481d2a0"),
     "4.28.0-nightly-2026-01-20": ("arena/v4.27.0-rc1","481d2a0"),
-# not yet supported upstream, it seems
-#   "4.29.0-rc1": ("arena/v4.27.0-rc1","d86be59"),
+    "4.29.0": ("arena/v4.29.0","9001336"),
 }
 
 # Base directory for lean4lean builds

--- a/tests/lean-toolchain
+++ b/tests/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.29.0-rc1
+leanprover/lean4:v4.29.0

--- a/tests/mathlib.yaml
+++ b/tests/mathlib.yaml
@@ -5,12 +5,9 @@ description: |
   from Mathlib, representing the largest and most comprehensive test case
   in the Lean kernel arena.
 
-  This test is based on a commit that includes
-  <https://github.com/leanprover-community/mathlib4/pull/33794> to include the performance fix
-  therein.
 url: https://github.com/leanprover-community/mathlib4
-ref: master
-rev: 7acaa1e4b353e8a5f9044f9bb0b68460079533a6
+ref: v4.29.0
+rev: 8a178386ffc0f5fef0b77738bb5449d50efeea95
 pre-build: lake exe cache get
 module: Mathlib
 outcome: accept


### PR DESCRIPTION
## Summary
- Add lean4lean `arena/v4.29.0` branch (cherry-picked arena adapter onto upstream v4.29.0)
- Update lean4lean-wrapper to map `4.29.0` → `arena/v4.29.0` (rev 9001336)
- Update tests/lean-toolchain to v4.29.0
- Update mathlib test to use v4.29.0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)