### PR TITLE
bump nanobruijn: lean Expr, cache cleanup

### DIFF
--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -26,7 +26,7 @@ description: |
   modifications from the original nanoda_lib were written by Claude (Anthropic).
 url: https://github.com/nomeata/nanobruijn
 ref: master
-rev: 97a206e13f0cf6d20459f03d48c1bac975726130
+rev: 99e58d6b690efb46a742056da92d01232cce80a1
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
Update nanobruijn to 99e58d6. Key changes since 97a206e:

- Remove num_loose_bvars and has_fvars fields from Expr variants.
  nlbv lives only in the parallel expr_nlbv Vec; has_fvars becomes lazy
  memoized (only queried on non-hot paths). mk_app is now pure ExprPtr
  arithmetic. Init -6.6%.
- Compute Expr hash on demand (removed the stored hash field).
- Remove caches subsumed by UF or by alloc_expr hash-consing:
  defeq_pos, mk_pi_cache, mk_lambda_cache, strong_cache, eq_cache.
- Add is_* head-check helpers and view_*_head partial views; hot paths
  avoid the expensive view_expr body-traversal where a tag check or
  subset of children suffices.
- unfold_pi_step / unfold_lambda_step helpers marked #[inline] for
  binder-telescope walks.
