### PR TITLE
Add the Sonanoda kernel to the arena

### DIFF
--- a/checkers/sonanoda.yaml
+++ b/checkers/sonanoda.yaml
@@ -9,8 +9,8 @@ description: |
   `h` and `h'` both necessarily share the same expected type.
 
   This is an experimental checker, not intended for production use.
-url: https://github.com/datokrat/nanoda_lib
-ref: fast-proof-irrel
+url: https://github.com/datokrat/sonanoda
+ref: master
 rev: 9e4ee399fa8e6d80f7b208e58647937f919a7eed
 build: |
   cargo build --release

--- a/checkers/sonanoda.yaml
+++ b/checkers/sonanoda.yaml
@@ -1,0 +1,28 @@
+description: |
+  **Sonanoda** - An experimental Lean 4 kernel with a shortcut for proof-irrelevant definitonal equality
+
+  Forked from [nanoda_lib](https://github.com/ammkrn/nanoda_lib).
+  This variant, when checking two terms for definitional equality, skips comparing
+  the types of proof terms.
+  Example: In `f a h b =?= f a' h' b'`, it suffices to ensure `a =?= a'` and `b =?= b'`
+  provided that the two applications are known to be well-typed; in that case,
+  `h` and `h'` both necessarily share the same expected type.
+
+  This is an experimental checker, not intended for production use.
+url: https://github.com/datokrat/nanoda_lib
+ref: fast-proof-irrel
+rev: 9e4ee399fa8e6d80f7b208e58647937f919a7eed
+build: |
+  cargo build --release
+  cat > config.json <<__END__
+   {
+     "use_stdin": true,
+     "nat_extension": true,
+     "string_extension": true,
+     "unpermitted_axiom_hard_error": false,
+     "unsafe_permit_all_axioms": true,
+     "num_threads": 4
+   }
+  __END__
+run: |
+  target/release/nanoda_bin config.json < "$IN" || exit 1


### PR DESCRIPTION
This PR adds the Sonanoda kernel to the arena.

Sonanoda is an experimental, minimally modified variant of Nanoda with a more efficient definitional equality check. When comparing proof terms, it skips comparing their types when it seemed safe.

On my local machine, Sonanoda is 31% faster than Nanoda in the arena. In pathological situations such as simplifying `xs[xs[xs[...[xs[0 + i]]]]]`, I found that Sonanoda's optimization can mean the difference between quadratic and linear time.