### PR TITLE
bump sonanoda: fix cache bug

### DIFF
--- a/checkers/sonanoda.yaml
+++ b/checkers/sonanoda.yaml
@@ -11,7 +11,7 @@ description: |
   This is an experimental checker, not intended for production use.
 url: https://github.com/datokrat/sonanoda
 ref: master
-rev: 9e4ee399fa8e6d80f7b208e58647937f919a7eed
+rev: 22e5940e8e5c7c27e9290dfa26fb6dff31905e7e
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
This PR bumps the sonanoda checker after fixing a caching-related bug. It's a logical bug and I'm not sure yet whether it can be exploited to make sonanoda accept terms it shouldn't accept. I intend to contribute a test for this if I can come up with one.