### PR TITLE
Add proj-of-prop soundness test

### DIFF
--- a/tests/proj-of-prop.lean
+++ b/tests/proj-of-prop.lean
@@ -1,27 +1,30 @@
 import Lean
-open Lean Meta Elab Term
-
-section Unchecked
-syntax (name := unchecked) "unchecked" term : term
-
-@[term_elab «unchecked»]
-def elabUnchecked : TermElab := fun stx expectedType? => do
-  match stx with
-  | `(unchecked $t) =>
-    let some expectedType := expectedType? |
-      tryPostpone
-      throwError "invalid 'unchecked', expected type required"
-    let e ← elabTerm t none
-    let mvar ← mkFreshExprMVar expectedType MetavarKind.syntheticOpaque
-    mvar.mvarId!.assign e
-    return mvar
-  | _ => throwUnsupportedSyntax
-
-end Unchecked
+open Lean Elab Command
 
 structure Wrapper : Prop where
   mk ::
   p : False
 
-set_option debug.skipKernelTC true in
-theorem badFalse : False := (Wrapper.mk (unchecked True.intro)).p
+/-
+The value we want to add is
+
+    Expr.proj `Wrapper 0 (Wrapper.mk True.intro)
+
+which has a `True.intro : True` sitting in the `Wrapper.mk` slot that
+expects a `False`. The elaborator never emits a raw `Expr.proj` from
+`(...).p` syntax (it desugars to the projection *function* `Wrapper.p`,
+which would get caught at `infer_app`), so we construct the declaration
+programmatically and hand it to `addDecl` under `debug.skipKernelTC`.
+-/
+
+run_cmd liftTermElabM do
+  let badValue : Expr :=
+    .proj `Wrapper 0 (mkApp (mkConst ``Wrapper.mk) (mkConst ``True.intro))
+  let decl : Declaration := .thmDecl {
+    name        := `badFalse
+    levelParams := []
+    type        := mkConst ``False
+    value       := badValue
+  }
+  withOptions (debug.skipKernelTC.set · true) do
+    addDecl decl

--- a/tests/proj-of-prop.lean
+++ b/tests/proj-of-prop.lean
@@ -1,0 +1,27 @@
+import Lean
+open Lean Meta Elab Term
+
+section Unchecked
+syntax (name := unchecked) "unchecked" term : term
+
+@[term_elab «unchecked»]
+def elabUnchecked : TermElab := fun stx expectedType? => do
+  match stx with
+  | `(unchecked $t) =>
+    let some expectedType := expectedType? |
+      tryPostpone
+      throwError "invalid 'unchecked', expected type required"
+    let e ← elabTerm t none
+    let mvar ← mkFreshExprMVar expectedType MetavarKind.syntheticOpaque
+    mvar.mvarId!.assign e
+    return mvar
+  | _ => throwUnsupportedSyntax
+
+end Unchecked
+
+structure Wrapper : Prop where
+  mk ::
+  p : False
+
+set_option debug.skipKernelTC true in
+theorem badFalse : False := (Wrapper.mk (unchecked True.intro)).p

--- a/tests/proj-of-prop.yaml
+++ b/tests/proj-of-prop.yaml
@@ -1,0 +1,19 @@
+description: |
+  A proof of `False` via a projection from a `Prop`-typed structure whose
+  constructor was applied to an ill-typed argument. The exported term is
+
+      badFalse : False := (Wrapper.mk True.intro).p
+
+  where `Wrapper : Prop` has a single field `p : False`, so `Wrapper.mk`
+  expects a proof of `False` but is given `True.intro : True`.
+
+  A sound checker must reject this. A checker that types a projection by
+  inferring (rather than checking) its structure argument — i.e. that
+  trusts the structure to be well-typed instead of verifying the
+  constructor's argument types against its binders — will accept it,
+  because `Wrapper.mk True.intro` still formally inhabits `Wrapper` at
+  the structural level, and the `p` projection is then read back out at
+  the declared field type `False`.
+leanfile: tests/proj-of-prop.lean
+export-decls: ["badFalse"]
+outcome: reject


### PR DESCRIPTION
The exported theorem builds a proof of `False` via a projection from a
`Prop`-typed structure whose constructor was applied to an ill-typed
argument:

    structure Wrapper : Prop where mk :: p : False
    theorem badFalse : False := (Wrapper.mk True.intro).p

A checker that types a projection by inferring (rather than checking)
its structure — trusting the structure to be well-typed rather than
verifying the constructor's arguments against its binders — will accept
this and return `badFalse : False`. A sound checker must reject it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
