### PR TITLE
bump nanobruijn: port upstream nanoda infer_proj fix

### DIFF
--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -26,7 +26,7 @@ description: |
   modifications from the original nanoda_lib were written by Claude (Anthropic).
 url: https://github.com/nomeata/nanobruijn
 ref: master
-rev: 99e58d6b690efb46a742056da92d01232cce80a1
+rev: 8fad81222f80368eb2d305741d50f230bd9c09f1
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
Picks up nomeata/nanobruijn 8fad812, which ports the upstream
ammkrn/nanoda_lib PR #19 fix (forward `flag` parameter in infer_proj).
This is the same fix that landed in nanoda via PR #37.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
