### PR TITLE
New tutorial test, ndjson formatting tests

### DIFF
--- a/checkers/nanoda.yaml
+++ b/checkers/nanoda.yaml
@@ -32,3 +32,5 @@ build: |
   __END__
 run: |
   target/release/nanoda_bin config.json < "$IN"
+  e=$?
+  exit $(( e==101 ? 1 : e ))

--- a/checkers/nanoda.yaml
+++ b/checkers/nanoda.yaml
@@ -32,5 +32,8 @@ build: |
   __END__
 run: |
   target/release/nanoda_bin config.json < "$IN"
-  e=$?
-  exit $(( e==101 ? 1 : e ))
+  case $? in 
+    0) exit 0 ;;
+    2) exit 2 ;;
+    *) exit 1 ;;
+  esac

--- a/checkers/nanoda.yaml
+++ b/checkers/nanoda.yaml
@@ -31,4 +31,4 @@ build: |
    }
   __END__
 run: |
-  target/release/nanoda_bin config.json < "$IN" || exit 1
+  target/release/nanoda_bin config.json < "$IN"

--- a/tests/level-index-out-of-order.ndjson
+++ b/tests/level-index-out-of-order.ndjson
@@ -1,0 +1,6 @@
+{"meta":{"exporter":{"name":"handcrafted","version":"0.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"2fcce7258eeb6e324366bc25f9058293b04b7547","version":"4.27.0-rc1"}}}
+{"in":1,"str":{"pre":0,"str":"foo"}}
+{"il":2,"succ":0}
+{"il":1,"succ":2}
+{"ie":0,"sort":1}
+{"axiom":{"isUnsafe":false,"levelParams":[],"name":1,"type":0}}

--- a/tests/level-index-out-of-order.yaml
+++ b/tests/level-index-out-of-order.yaml
@@ -1,0 +1,16 @@
+description: |
+  Lean4export will create internalization-table references contiguously in
+  order: `in` references for names, `il` references for levels, and `ie`
+  references for expressions all work this way.
+
+  However, the spec merely requires that these are integers. It's reasonable
+  for an implementation to assume these are approximately dense (and to treat
+  them as array indices instead of hashtable entries), but a kernel should
+  handle skipped indices or out-of-order indices.
+
+  This test checks that the kernel doesn't require internaliation-table
+  references to be presented in ascending order. If the level referenes 2 and
+  1 were swapped, this would be the expected encoding of `axiom foo : Sort 2`.
+  This encoding should be equivalent.
+file: tests/level-index-out-of-order.ndjson
+outcome: accept

--- a/tests/sparse-name-index.ndjson
+++ b/tests/sparse-name-index.ndjson
@@ -1,0 +1,4 @@
+{"meta":{"exporter":{"name":"handcrafted","version":"0.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"2fcce7258eeb6e324366bc25f9058293b04b7547","version":"4.27.0-rc1"}}}
+{"in":2,"str":{"pre":0,"str":"foo"}}
+{"ie":4,"sort":0}
+{"axiom":{"isUnsafe":false,"levelParams":[],"name":2,"type":4}}

--- a/tests/sparse-name-index.yaml
+++ b/tests/sparse-name-index.yaml
@@ -1,0 +1,16 @@
+description: |
+  Lean4export will create internalization-table references contiguously in
+  order: `in` references for names, `il` references for levels, and `ie`
+  references for expressions all work this way.
+
+  However, the spec merely requires that these are integers. It's reasonable
+  for an implementation to assume these are approximately dense (and to treat
+  them as array indices instead of hashtable entries), but a kernel should
+  handle skipped indices or out-of-order indices.
+
+  This test checks that a kernel doesn't require internalization-table
+  references to be assigned sequentially starting from 1. If the "2" and "4" 
+  were replaced by "1" and "0", respectively, this would be the expected 
+  encoding of `axiom foo : Prop`. This encoding should be equivalent.
+file: tests/sparse-name-index.ndjson
+outcome: accept

--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -1252,12 +1252,19 @@ bad_consts #[`dupDef, `DupInd]
   renaming #[(`DupInd, `dup_rec_def), (`DupInd.mk, `dup_rec_def.mk), (`DupInd.rec, `dup_rec_def.rec), (`dupDef, `dup_rec_def.rec)]
 
 /--
-A definition with the name of a recursor, and the recursor named differently.
-This would pass simple checks for duplicate definitions in the parser, but should still
-be rejected by the checker.
+The name of the recursor for `misnamed_rec` must be `misnamed_rec.rec`:
+another name (like `misnamed_rec.invalid_rec`) should be rejected.
+-/
+bad_consts #[`DupInd]
+  renaming #[(`DupInd, `misnamed_rec), (`DupInd.mk, `misnamed_rec.mk), (`DupInd.rec, `misnamed_rec.not_rec)]
+
+/--
+Even if a kernel doesn't catch a recursor for `dup_rec_def2` that is misnamed
+as `dup_rec_def2.not_rec`, it should catch some *other* constant being given
+the name `dup_rec_def2.rec` that is reserved for the recursor.
 -/
 bad_consts #[`dupDef, `DupInd]
-  renaming #[(`DupInd, `dup_rec_def2), (`DupInd.mk, `dup_rec_def2.mk), (`DupInd.rec, `dup_rec_def2.original_rec), (`dupDef, `dup_rec_def2.rec)]
+  renaming #[(`DupInd, `dup_rec_def2), (`DupInd.mk, `dup_rec_def2.mk), (`DupInd.rec, `dup_rec_def2.not_rec), (`dupDef, `dup_rec_def2.rec)]
 
 /-- A constructor and a recursor with the same name -/
 bad_consts #[`DupInd]


### PR DESCRIPTION
According to a Claude investigation, the current `dup_rec_def2` is actually failed by `nanoda` for a "bad reason" — because the renaming machinery doesn't create continguously-numbered internalization-table references, which nanoda requires. This adds two tests that expose this issue in nanoda.

Also adds a new tutorial test that checks the same behavior more rigorously: based on the behavior of the Lean kernel, it seems like any attempt to name the recursor anything besides `<Inductive>.rec` should fail, regardless of whether a new declaration tries to use the reserved space.