### PR TITLE
Add meta header to large-elim-param.ndjson

### DIFF
--- a/tests/large-elim-param.ndjson
+++ b/tests/large-elim-param.ndjson
@@ -1,4 +1,4 @@
-{}
+{"meta":{"format":{"version":"3.1.0"}}}
 {"in": 1, "str": {"pre": 0, "str": "False"}}
 {"in": 2, "str": {"pre": 0, "str": "True"}}
 {"in": 3, "str": {"pre": 2, "str": "intro"}}


### PR DESCRIPTION
## Summary
- Replace the empty `{}` first line of `tests/large-elim-param.ndjson` with a `meta` record matching the convention used by every other ndjson test.
- Uses a format-only meta (`{"format":{"version":"3.1.0"}}`) since this file was hand-authored from a [Zulip bounty submission](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/T-Shirt.20bounty.20for.20breaking.20the.20.E2.80.9Cmini-kernel.E2.80.9D/near/597318744), not produced by lean4export — so claiming an exporter/lean version would be inaccurate.

The missing header didn't fail CI because `extract_ndjson_metadata` in `lka.py` swallows all errors silently and there is no JSON Schema for the exporter NDJSON format (only for the YAML test/checker configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)