### PR TITLE
extend basic proofirrelevance tests

### DIFF
--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -952,8 +952,24 @@ good_decl (.thmDecl {
 
 /-! Proof irrelevance and unit Eta -/
 
-/-- Proof irrelevance -/
+/--
+Proof irrelevance: every `Prop` is a subsingleton, if `p : Prop` then all elements of `p`
+are definitionally equal.
+-/
 good_def proofIrrelevance : ∀ (p : Prop) (h1 h2 : p), h1 = h2 := fun _ _ _ => rfl
+
+/--
+Proof irrelevance is limited to Prop: if `p : Type`, then all elements of `p` are *not*
+definitionally equal.
+-/
+bad_def proofIrrelevanceBad : ∀ (p : Type) (h1 h2 : p), h1 = h2 :=
+  unchecked (fun (p : Type) (h1 h2 : p) => @rfl p h1)
+
+/--
+Proof irrelevance: if `p : A` and `A` is definitionally equal to `Prop`, then all elements of `p`
+are still definitionally equal. Just applying proof irrelevance at `Sort 0` isn't sufficient.
+-/
+good_def proofIrrelevanceWhnf : ∀ (p : id Prop) (h1 h2 : p), h1 = h2 := fun _ _ _ => rfl
 
 /-- Unit eta -/
 good_def unitEta1 : ∀ (x y : Unit), x = y := fun _ _ => rfl


### PR DESCRIPTION
Add more description to the `proofIrrelevance` tutorial test and inserts two sibling tests: one that fails at Type and one that succeeds at `id Prop`, which is defeq to `Prop`.

I'll let others be the judge of whether these are productive tutorial tests; they seem useful to me in helping me understand how a Lean kernel is actually supposed to behave.