### PR TITLE
Fix invalid NDJSON in the large elim param test.

### DIFF
--- a/tests/large-elim-param.ndjson
+++ b/tests/large-elim-param.ndjson
@@ -36,7 +36,7 @@
 {"ie": 17, "forallE": {"name": 11, "type": 11, "body": 16, "binderInfo": "default"}}
 {"ie": 18, "lam": {"name": 12, "type": 13, "body": 12, "binderInfo": "default"}}
 {"ie": 19, "lam": {"name": 11, "type": 11, "body": 18, "binderInfo": "default"}}
-{"def": {"name": 9, "levelParams": [], "type": 17, "value": 19, "hints": {"kind": "opaque"}, "safety": "safe", "all": [9]}}
+{"def": {"name": 9, "levelParams": [], "type": 17, "value": 19, "hints": "opaque", "safety": "safe", "all": [9]}}
 {"ie": 20, "const": {"name": 8, "us": [1, 0]}}
 {"ie": 21, "lam": {"name": 13, "type": 7, "body": 1, "binderInfo": "default"}}
 {"ie": 22, "app": {"fn": 20, "arg": 21}}


### PR DESCRIPTION
This used the old non-3.1.0-export-format hints syntax.

https://github.com/leanprover/lean4export/blob/master/format_ndjson.md