### PR TITLE
feat: run checkers in parallel

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,7 +20,7 @@ jobs:
           mode: create
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
-          server_type: ccx23
+          server_type: ccx43
           location: nbg1  # Nuremberg, Germany
           image: ubuntu-24.04
           ssh_key: ${{ secrets.HCLOUD_SSH_KEY_ID }}
@@ -29,7 +29,7 @@ jobs:
     needs: create-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.create-runner.outputs.label || 'ubuntu-latest' }} # run on custom runner if available, otherwise default
     if: always() # Run even if create-runner was skipped
-    timeout-minutes: 600
+    timeout-minutes: 120
     
     permissions:
       contents: read

--- a/checkers/nanobruijn.yaml
+++ b/checkers/nanobruijn.yaml
@@ -27,6 +27,7 @@ description: |
 url: https://github.com/nomeata/nanobruijn
 ref: master
 rev: 5a42fcc40f97901f886f8fe176d2f4dcd798db7e
+threads: 4
 build: |
   cargo build --release
   cat > config.json <<__END__

--- a/checkers/nanoda.yaml
+++ b/checkers/nanoda.yaml
@@ -18,6 +18,7 @@ description: |
 url: https://github.com/ammkrn/nanoda_lib
 ref: master
 rev: f58f2f6d535e189a40fcb02ede8eb95f97a92d37
+threads: 4
 build: |
   cargo build --release
   cat > config.json <<__END__

--- a/checkers/sokonanoda.yaml
+++ b/checkers/sokonanoda.yaml
@@ -9,6 +9,7 @@ description: |
 url: https://github.com/intgrah/sokonanoda
 ref: master
 rev: f1c4b12ca88a37fcc030eef2a59260a4a2d04a24
+threads: 4
 build: |
   cargo build --release
   cat > config.json <<__END__

--- a/checkers/still-nanoda.yaml
+++ b/checkers/still-nanoda.yaml
@@ -3,6 +3,7 @@ description: |
 url: https://github.com/SchrodingerZhu/still-nanoda
 ref: cache-study-port
 rev: 06a07b74436f8a111df836312ccac3a41b93c7b6
+threads: 4
 build: |
   cargo build --release
   cat > config.json <<__END__

--- a/lka.py
+++ b/lka.py
@@ -10,6 +10,7 @@
 """Lean Kernel Arena - Tool for managing Lean kernel tests and checkers."""
 
 import argparse
+import concurrent.futures
 import datetime
 import fnmatch
 import json
@@ -18,6 +19,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -1258,6 +1260,26 @@ def run_checker_on_test(checker: dict, test: dict, build_dir: Path, tests_dir: P
     return result_data
 
 
+class CoreBudget:
+    def __init__(self, total: int):
+        self.total = max(1, total)
+        self.available = self.total
+        self.cond = threading.Condition()
+
+    def acquire(self, cores: int) -> int:
+        cores = max(1, min(cores, self.total))
+        with self.cond:
+            while self.available < cores:
+                self.cond.wait()
+            self.available -= cores
+        return cores
+
+    def release(self, cores: int) -> None:
+        with self.cond:
+            self.available += cores
+            self.cond.notify_all()
+
+
 def cmd_run_checker(args: argparse.Namespace) -> int:
     """Handle the run command."""
     build_dir = get_project_root() / "_build" / "checkers"
@@ -1303,13 +1325,31 @@ def cmd_run_checker(args: argparse.Namespace) -> int:
         print("No built tests found.")
         return 0
 
+    budget = args.jobs if args.jobs and args.jobs > 0 else (os.cpu_count() or 1)
+    cores = CoreBudget(budget)
+
+    def run_one(checker, test):
+        held = cores.acquire(int(checker.get("threads", 1) or 1))
+        try:
+            return run_checker_on_test(checker, test, build_dir, tests_dir, results_dir)
+        finally:
+            cores.release(held)
+
     results = []
-    for checker in checkers:
-        for test in tests:
-            print(f"Running {checker['name']} on {test['name']}...", end="\n" if VERBOSE else " ")
-            result = run_checker_on_test(checker, test, build_dir, tests_dir, results_dir)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=budget) as executor:
+        futures = {}
+        for checker in checkers:
+            for test in tests:
+                future = executor.submit(run_one, checker, test)
+                futures[future] = (checker, test)
+
+        for future in concurrent.futures.as_completed(futures):
+            checker, test = futures[future]
+            result = future.result()
             results.append(result)
-            
+
+            print(f"Ran {checker['name']} on {test['name']}", end="\n" if VERBOSE else " ")
+
             # Choose emoji based on status
             status = result.get('status', 'error')
             if status == 'accepted':
@@ -1946,6 +1986,13 @@ def main() -> int:
     run_checker_parser.add_argument(
         "--test",
         help="Name or glob pattern of the test to run (default: all tests)",
+    )
+    run_checker_parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=None,
+        help="CPU-core budget for parallel runs; each checker reserves its declared 'threads' (default: number of CPUs; 1 disables parallelism)",
     )
 
     # build-site command

--- a/schemas/checker.json
+++ b/schemas/checker.json
@@ -46,6 +46,11 @@
     "serious": {
       "type": "boolean",
       "description": "If false, this checker is omitted from the main comparison tables (default: true)"
+    },
+    "threads": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Worker threads the checker runs concurrently; the parallel runner reserves this many CPU slots to avoid oversubscribing (default: 1)"
     }
   },
   "required": ["run"],


### PR DESCRIPTION
Currently, the script runs all checker sequentially. I believe a 16-thread ccx43 will do the job faster, about €0.531 in 1 hour, compared to €0.165 for 6 hours.

Add a `threads: n` field to the schema to declare how many threads a checker would like.

Written with Claude.
