### PR TITLE
Bump lean4lean arena branches (merge upstream master)

### DIFF
--- a/checkers/lean4lean/lean4lean-wrapper.py
+++ b/checkers/lean4lean/lean4lean-wrapper.py
@@ -10,12 +10,12 @@ from pathlib import Path
 
 # Map from Lean toolchains to lean4lean git tags
 TOOLCHAIN_TO_TAG = {
-    "4.26.0": ("arena/v4.26.0","7a444cd"),
-    "4.27.0-nightly-2025-12-01": ("arena/v4.26.0","7a444cd"),
-    "4.27.0-rc1": ("arena/v4.27.0-rc1","481d2a0"),
-    "4.28.0-nightly-2026-01-19": ("arena/v4.27.0-rc1","481d2a0"),
-    "4.28.0-nightly-2026-01-20": ("arena/v4.27.0-rc1","481d2a0"),
-    "4.29.0": ("arena/v4.29.0","9001336"),
+    "4.26.0": ("arena/v4.26.0","16456b4"),
+    "4.27.0-nightly-2025-12-01": ("arena/v4.26.0","16456b4"),
+    "4.27.0-rc1": ("arena/v4.27.0-rc1","4098e75"),
+    "4.28.0-nightly-2026-01-19": ("arena/v4.27.0-rc1","4098e75"),
+    "4.28.0-nightly-2026-01-20": ("arena/v4.27.0-rc1","4098e75"),
+    "4.29.0": ("arena/v4.29.0","5000544"),
 }
 
 # Base directory for lean4lean builds


### PR DESCRIPTION
Merges `digama0/lean4lean` master into each arena branch of the fork and repins the wrapper:

| branch | old | new |
|--------|-----|-----|
| `arena/v4.26.0` | `7a444cd` | `16456b4` |
| `arena/v4.27.0-rc1` | `481d2a0` | `4098e75` |
| `arena/v4.29.0` | `9001336` | `5000544` |

Upstream master introduces a dynamic fuel config (`--config`/`--config:` flags, `FuelConfig`). Conflict resolutions:

- **`Main.lean`** — combined the arena `--import` handler with upstream's fuel-flag parsing (fuel is parsed first and threaded into the `--import` replay).
- **`Lean4Lean/TypeChecker.lean`** (v4.29.0) — took upstream's configurable fuel (`ctx.fuel.whnf`/`whnfEager`/`lazyDelta`), dropping the arena's hardcoded `1000000`.
- **`lake-manifest.json` / `lakefile.toml` / `lean-toolchain`** — kept each branch's own toolchain and batteries pin plus the `lean4export` dependency, discarding upstream's version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)