### PR TITLE
Consolidate tests at toolchain 4.29.1

### DIFF
--- a/checkers/lean4lean/lean4lean-wrapper.py
+++ b/checkers/lean4lean/lean4lean-wrapper.py
@@ -10,12 +10,8 @@ from pathlib import Path
 
 # Map from Lean toolchains to lean4lean git tags
 TOOLCHAIN_TO_TAG = {
-    "4.26.0": ("arena/v4.26.0","7a444cd"),
-    "4.27.0-nightly-2025-12-01": ("arena/v4.26.0","7a444cd"),
-    "4.27.0-rc1": ("arena/v4.27.0-rc1","481d2a0"),
-    "4.28.0-nightly-2026-01-19": ("arena/v4.27.0-rc1","481d2a0"),
-    "4.28.0-nightly-2026-01-20": ("arena/v4.27.0-rc1","481d2a0"),
-    "4.29.0": ("arena/v4.29.0","9001336"),
+    "4.29.0": ("arena/v4.29.0","50005444cce5317cc6cc044c9f0f36b54682b59f"),
+    "4.29.1": ("arena/v4.29.0","50005444cce5317cc6cc044c9f0f36b54682b59f"),
 }
 
 # Base directory for lean4lean builds

--- a/tests/cedar.yaml
+++ b/tests/cedar.yaml
@@ -7,7 +7,7 @@ description: |
   `Batteries.`
 url: https://github.com/cedar-policy/cedar-spec/
 ref: main
-rev: 2e9aa6b
+rev: f36af0f9fc038b9e6a340960fc24f3b610a84aee
 pre-build: |
   shopt -s dotglob && find . -mindepth 1 -maxdepth 1 ! -name cedar-lean -exec rm -rf {} + && mv cedar-lean/* . && rmdir cedar-lean
 module: Cedar

--- a/tests/constlevels.ndjson
+++ b/tests/constlevels.ndjson
@@ -1,4 +1,4 @@
-{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"83e54b65b65d1d3ce31d99d820a7bd5f3e219295","version":"4.29.0-rc2"}}}
+{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"83e54b65b65d1d3ce31d99d820a7bd5f3e219295","version":"4.29.1"}}}
 {"in":1,"str":{"pre":0,"str":"Nat"}}
 {"il":1,"succ":0}
 {"ie":0,"sort":1}

--- a/tests/cslib.yaml
+++ b/tests/cslib.yaml
@@ -2,7 +2,7 @@ description: |
   The Lean Computer Science Library (CSLib). 
 url: https://github.com/leanprover/cslib
 ref: main
-rev: 02e2a23eef42925cc87a5ce2ec76e9d07fdee267
+rev: d1dbe1ec53e08957ff4cb893d82f3e0f7eaa4b00
 pre-build: lake exe cache get
 module: Cslib
 outcome: accept

--- a/tests/lean-toolchain
+++ b/tests/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.29.0
+leanprover/lean4:v4.29.1

--- a/tests/level-imax-leq.ndjson
+++ b/tests/level-imax-leq.ndjson
@@ -1,4 +1,4 @@
-{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"0000000000000000000000000000000000000000","version":"4.29.0-rc1"}}}
+{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"0000000000000000000000000000000000000000","version":"4.29.1"}}}
 {"in":1,"str":{"pre":0,"str":"False"}}
 {"in":2,"str":{"pre":0,"str":"True"}}
 {"in":3,"str":{"pre":2,"str":"intro"}}

--- a/tests/level-imax-normalization.ndjson
+++ b/tests/level-imax-normalization.ndjson
@@ -1,4 +1,4 @@
-{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"0000000000000000000000000000000000000000","version":"4.26.0"}}}
+{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"0000000000000000000000000000000000000000","version":"4.29.1"}}}
 {"in":1,"str":{"pre":0,"str":"False"}}
 {"in":2,"str":{"pre":0,"str":"True"}}
 {"in":3,"str":{"pre":2,"str":"intro"}}

--- a/tests/level-index-out-of-order.ndjson
+++ b/tests/level-index-out-of-order.ndjson
@@ -1,4 +1,4 @@
-{"meta":{"exporter":{"name":"handcrafted","version":"0.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"2fcce7258eeb6e324366bc25f9058293b04b7547","version":"4.27.0-rc1"}}}
+{"meta":{"exporter":{"name":"handcrafted","version":"0.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"2fcce7258eeb6e324366bc25f9058293b04b7547","version":"4.29.1"}}}
 {"in":1,"str":{"pre":0,"str":"foo"}}
 {"il":2,"succ":0}
 {"il":1,"succ":2}

--- a/tests/mathlib.yaml
+++ b/tests/mathlib.yaml
@@ -6,8 +6,8 @@ description: |
   in the Lean kernel arena.
 
 url: https://github.com/leanprover-community/mathlib4
-ref: v4.29.0
-rev: 8a178386ffc0f5fef0b77738bb5449d50efeea95
+ref: v4.29.1
+rev: 5e932f97dd25535344f80f9dd8da3aab83df0fe6
 pre-build: lake exe cache get
 module: Mathlib
 outcome: accept

--- a/tests/nat-rec-rules.ndjson
+++ b/tests/nat-rec-rules.ndjson
@@ -1,4 +1,4 @@
-{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"0000000000000000000000000000000000000000","version":"4.29.0-rc1"}}}
+{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"0000000000000000000000000000000000000000","version":"4.29.1"}}}
 {"in":1,"str":{"pre":0,"str":"False"}}
 {"in":2,"str":{"pre":1,"str":"rec"}}
 {"in":3,"str":{"pre":0,"str":"True"}}

--- a/tests/sparse-name-index.ndjson
+++ b/tests/sparse-name-index.ndjson
@@ -1,4 +1,4 @@
-{"meta":{"exporter":{"name":"handcrafted","version":"0.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"2fcce7258eeb6e324366bc25f9058293b04b7547","version":"4.27.0-rc1"}}}
+{"meta":{"exporter":{"name":"handcrafted","version":"0.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"2fcce7258eeb6e324366bc25f9058293b04b7547","version":"4.29.1"}}}
 {"in":2,"str":{"pre":0,"str":"foo"}}
 {"ie":4,"sort":0}
 {"axiom":{"isUnsafe":false,"levelParams":[],"name":2,"type":4}}

--- a/tutorial/lean-toolchain
+++ b/tutorial/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.27.0-rc1
+leanprover/lean4:v4.29.1


### PR DESCRIPTION
Including an update to cedar, cslib and lean4lean.