### PR TITLE
Add vow-lean-kernel checker

### DIFF
--- a/checkers/vow-lean-kernel.yaml
+++ b/checkers/vow-lean-kernel.yaml
@@ -34,18 +34,10 @@ build: |
   git clone https://github.com/vow-lang/vow vow
   git -C vow checkout "$VOW_REF"
 
-  # vow's Rust deps (cranelift 0.133) need rustc >= 1.94, newer than some build
-  # environments provide (e.g. the arena's nixpkgs-pinned rustc 1.91.1). Install
-  # a known-good toolchain via rustup and put it first on PATH for the Rust
-  # build. Only stage 0 needs cargo/rustc; the self-host and kernel builds use
-  # the produced binaries. (curl reaches the host /usr/bin here — the same path
-  # the arena's `nix develop` shell uses for git.)
-  export RUSTUP_HOME="$ROOT/.rustup" CARGO_HOME="$ROOT/.cargo"
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o "$ROOT/rustup-init.sh"
-  sh "$ROOT/rustup-init.sh" -y --profile minimal --default-toolchain 1.96.0 --no-modify-path
-  export PATH="$CARGO_HOME/bin:$PATH"
-
-  # Stage 0: Rust bootstrap compiler.
+  # Stage 0: Rust bootstrap compiler. vow's Rust deps (cranelift 0.133) need
+  # rustc >= 1.94, provided by the arena's flake (nixpkgs nixos-26.05 → rustc
+  # 1.95). Only this stage needs cargo/rustc; the self-host and kernel builds
+  # use the produced binaries.
   ( cd vow && cargo build --all )
 
   # Stage 1: concatenate and self-host the Cranelift-backed `vowc`. The
@@ -64,18 +56,21 @@ run: |
   # lean_checker exits 0 accept / 1 reject / 2 decline. But the Vow runtime
   # exits 1 on OutOfMemory, colliding with "reject" — which the arena would
   # score as a false reject on an accept test. Detect that specific runtime OOM
-  # (a JSON marker on stderr) and report it as a decline (exit 2): an honest
-  # "exceeded my memory budget", not a claim that the proof is invalid. Genuine
-  # rejects (exit 1, no OOM marker) and real crashes are left untouched.
+  # (a JSON marker on stderr) and remap it to exit 3 (error). An OOM is a
+  # resource-exhaustion abort, not a deliberate "outside my fragment" decline,
+  # so the arena's error bucket (crash / OOM / timeout) is its honest home.
+  # Genuine rejects (exit 1, no OOM marker), real declines (exit 2) and real
+  # crashes are left untouched.
   #
   # Cap = 12 GiB: the dry-run showed the `Init` accept run peaks at ~7.6 GB, so
   # 8 GB left almost no headroom; 12 GB is comfortable yet stays below a normal
   # arena host's RAM, so a genuine OOM still surfaces as Vow's graceful
-  # allocation failure (→ decline) rather than an OS OOM-kill (uncatchable).
+  # allocation failure (which we can detect) rather than an OS OOM-kill
+  # (SIGKILL, uncatchable).
   err="$(mktemp)"
   ( ulimit -v 12582912 && ./lean_checker "$IN" ) 2>"$err"
   rc=$?
   cat "$err" >&2
-  if [ "$rc" -ne 0 ] && grep -q '"error":"OutOfMemory"' "$err"; then rc=2; fi
+  if [ "$rc" -ne 0 ] && grep -q '"error":"OutOfMemory"' "$err"; then rc=3; fi
   rm -f "$err"
   exit "$rc"

--- a/checkers/vow-lean-kernel.yaml
+++ b/checkers/vow-lean-kernel.yaml
@@ -1,0 +1,70 @@
+# Lean Kernel Arena checker: a Lean 4 kernel written in Vow.
+# Source of truth: https://github.com/pmatos/vow-lean-kernel (arena/checker.yaml).
+#
+# `url`-type checker. The arena clones the kernel repo into `src/`, runs `build`
+# there, then `run` with `$IN` = the NDJSON test file. `build`/`run` are executed
+# via `/bin/sh -c`, so they stay POSIX-sh compatible (the internal scripts/*.sh
+# invoke bash explicitly).
+version: "0.1.0"
+description: |
+  A Lean 4 kernel (proof checker) written in [**Vow**](https://github.com/vow-lang/vow),
+  a young systems language. Reads `lean4export` NDJSON and verifies each
+  declaration is well-typed.
+
+  It accepts the full Arena tutorial suite and all of Lean core `Init`
+  (54,475 declarations). Nat arithmetic uses a base-2^32 bignum backend, so
+  reductions past 2^64 are exact. Declarations beyond the currently supported
+  fragment are **declined** (exit 2) rather than falsely rejected — the checker
+  is sound-by-construction on what it accepts and conservative elsewhere.
+
+  This is the first large program written in Vow and doubles as a proving ground
+  for the language.
+url: https://github.com/pmatos/vow-lean-kernel
+ref: main
+rev: 514ab33fc0262c491a0af1846cc3887f48411e36
+build: |
+  set -eu
+
+  # The kernel builds only with the self-hosted `vowc`, which must first be
+  # built from vow-lang/vow at this pinned commit (the base-2^32 bignum merge
+  # the kernel is developed against). Mirrors .github/workflows/ci.yml.
+  VOW_REF=15c1b933f87eed2b23c176665730baea37706daa
+  ROOT="$(pwd)"
+
+  git clone https://github.com/vow-lang/vow vow
+  git -C vow checkout "$VOW_REF"
+
+  # Stage 0: Rust bootstrap compiler.
+  ( cd vow && cargo build --all )
+
+  # Stage 1: concatenate and self-host the Cranelift-backed `vowc`. The
+  # self-host build is memory-capped in a subshell so the cap does not leak into
+  # the kernel build that follows.
+  ( cd vow && bash scripts/concat_vow.sh clif > "$ROOT/compiler_clif.vow" )
+  ( cd vow && ulimit -v 2000000 \
+      && ./target/debug/vow build --no-verify --no-cache \
+           "$ROOT/compiler_clif.vow" -o "$ROOT/vowc" )
+  test -x "$ROOT/vowc"
+
+  # Stage 2: build the kernel with the freshly self-hosted vowc.
+  VOWC="$ROOT/vowc" bash scripts/build.sh
+  test -x lean_checker
+run: |
+  # lean_checker exits 0 accept / 1 reject / 2 decline. But the Vow runtime
+  # exits 1 on OutOfMemory, colliding with "reject" — which the arena would
+  # score as a false reject on an accept test. Detect that specific runtime OOM
+  # (a JSON marker on stderr) and report it as a decline (exit 2): an honest
+  # "exceeded my memory budget", not a claim that the proof is invalid. Genuine
+  # rejects (exit 1, no OOM marker) and real crashes are left untouched.
+  #
+  # Cap = 12 GiB: the dry-run showed the `Init` accept run peaks at ~7.6 GB, so
+  # 8 GB left almost no headroom; 12 GB is comfortable yet stays below a normal
+  # arena host's RAM, so a genuine OOM still surfaces as Vow's graceful
+  # allocation failure (→ decline) rather than an OS OOM-kill (uncatchable).
+  err="$(mktemp)"
+  ( ulimit -v 12582912 && ./lean_checker "$IN" ) 2>"$err"
+  rc=$?
+  cat "$err" >&2
+  if [ "$rc" -ne 0 ] && grep -q '"error":"OutOfMemory"' "$err"; then rc=2; fi
+  rm -f "$err"
+  exit "$rc"

--- a/checkers/vow-lean-kernel.yaml
+++ b/checkers/vow-lean-kernel.yaml
@@ -17,8 +17,13 @@ description: |
   fragment are **declined** (exit 2) rather than falsely rejected — the checker
   is sound-by-construction on what it accepts and conservative elsewhere.
 
-  This is the first large program written in Vow and doubles as a proving ground
-  for the language.
+  [Vow](https://vow-lang.com) is a language developed by Paulo Matos
+  ([github.com/pmatos](https://github.com/pmatos)) for agentic use — one of
+  several such languages currently emerging, alongside MoonBit, Vera-lang, and
+  Zerolang. This kernel, the first large program written in Vow, was undertaken
+  as a challenge: to have an agent develop a complete Lean kernel entirely in the
+  new language, and it doubles as a proving ground for it. The work was 100%
+  agentic, carried out with Claude Code.
 url: https://github.com/pmatos/vow-lean-kernel
 ref: main
 rev: 514ab33fc0262c491a0af1846cc3887f48411e36

--- a/checkers/vow-lean-kernel.yaml
+++ b/checkers/vow-lean-kernel.yaml
@@ -34,6 +34,17 @@ build: |
   git clone https://github.com/vow-lang/vow vow
   git -C vow checkout "$VOW_REF"
 
+  # vow's Rust deps (cranelift 0.133) need rustc >= 1.94, newer than some build
+  # environments provide (e.g. the arena's nixpkgs-pinned rustc 1.91.1). Install
+  # a known-good toolchain via rustup and put it first on PATH for the Rust
+  # build. Only stage 0 needs cargo/rustc; the self-host and kernel builds use
+  # the produced binaries. (curl reaches the host /usr/bin here — the same path
+  # the arena's `nix develop` shell uses for git.)
+  export RUSTUP_HOME="$ROOT/.rustup" CARGO_HOME="$ROOT/.cargo"
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o "$ROOT/rustup-init.sh"
+  sh "$ROOT/rustup-init.sh" -y --profile minimal --default-toolchain 1.96.0 --no-modify-path
+  export PATH="$CARGO_HOME/bin:$PATH"
+
   # Stage 0: Rust bootstrap compiler.
   ( cd vow && cargo build --all )
 

--- a/checkers/vow-lean-kernel.yaml
+++ b/checkers/vow-lean-kernel.yaml
@@ -72,8 +72,11 @@ run: |
   # arena host's RAM, so a genuine OOM still surfaces as Vow's graceful
   # allocation failure (which we can detect) rather than an OS OOM-kill
   # (SIGKILL, uncatchable).
+  #
+  # Time cap = 30s: unsupported performance cases should fail promptly instead
+  # of occupying an arena runner until the workflow-wide timeout.
   err="$(mktemp)"
-  ( ulimit -v 12582912 && ./lean_checker "$IN" ) 2>"$err"
+  ( ulimit -v 12582912 && timeout 30s ./lean_checker "$IN" ) 2>"$err"
   rc=$?
   cat "$err" >&2
   if [ "$rc" -ne 0 ] && grep -q '"error":"OutOfMemory"' "$err"; then rc=3; fi

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773068389,
-        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
   outputs = { self, nixpkgs }:
     let
       system = "x86_64-linux";


### PR DESCRIPTION
Adds a checker for **[vow-lean-kernel](https://github.com/pmatos/vow-lean-kernel)** — a Lean 4 kernel written in [**Vow**](https://github.com/vow-lang/vow), a young systems language. It's a fresh, independent implementation in a host language not yet represented in the arena, so it adds to the implementation diversity the arena is after.

### What it is

A `url`-type checker. `build` self-hosts the Vow compiler (`vowc`) from `vow-lang/vow` at a pinned commit, then builds the kernel with it (the kernel builds only with the self-hosted `vowc`); this mirrors the project's own CI. `run` reads the NDJSON and exits per the arena protocol.

Needs `cargo`/Rust and `git` at build time (both already used by other checkers here, e.g. nanoda).

### Coverage

- Accepts the full **tutorial** suite and all of Lean core **`Init`** (54,475 declarations).
- Nat arithmetic uses a base-2³² bignum backend, so reductions past 2⁶⁴ are exact.
- Declarations beyond the currently supported fragment are **declined** (exit 2), never falsely rejected — sound on what it accepts, conservative elsewhere.

### Dry-run (local, `ulimit -v 12G`)

| test | verdict | notes |
|------|---------|-------|
| init | **accept** | all 54,475 core `Init` declarations |
| std | **decline** | exhausts the memory budget partway |
| mathlib | **decline** | the full export exceeds the budget while loading |

No false rejects and no crashes. One implementation note baked into `run`: the Vow runtime exits `1` on OutOfMemory, which would collide with the arena's *reject* code, so an OOM is detected and reported as a **decline** instead (tracked upstream as [vow-lang/vow#877](https://github.com/vow-lang/vow/issues/877)).

### Validation

- `checker.yaml` validates against `schemas/checker.json`.
- The `build` was reproduced from a clean checkout (fresh `vow-lang/vow` clone → `cargo build --all` → self-hosted `vowc` → `lean_checker`).
- The project's tutorial suite passes 131/131 on the resulting binary.
