### PR TITLE
Add nyaya OCaml checker

### DIFF
--- a/checkers/nyaya.yaml
+++ b/checkers/nyaya.yaml
@@ -1,0 +1,10 @@
+description: |
+  nyaya -- an external Lean 4 kernel written in OCaml. 
+url: https://github.com/kodyvajjha/nyaya
+ref: master
+rev: a748f56ffd8fee099ad3a6a3e682156d42d51781
+build: |
+  export OPAMROOT="$PWD/.opam-root"
+  opam init --bare --disable-sandboxing -n
+  opam switch create . ocaml-system -y
+run: NYAYA_ARENA=1 ./_opam/bin/nyaya "$IN"

--- a/checkers/nyaya.yaml
+++ b/checkers/nyaya.yaml
@@ -7,4 +7,6 @@ build: |
   export OPAMROOT="$PWD/.opam-root"
   opam init --bare --disable-sandboxing -n
   opam switch create . ocaml-system -y
-run: NYAYA_ARENA=1 ./_opam/bin/nyaya "$IN"
+run: |
+  ulimit -v 1000000 -c 0
+  NYAYA_ARENA=1 timeout 30s ./_opam/bin/nyaya "$IN"

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
         buildInputs = with pkgs; [
           (python3.withPackages (p : with p; [ jinja2 pyyaml jsonschema markdown ]))
           elan
-          rustc 
+          rustc
           cargo
           perf
           libffi
@@ -21,6 +21,9 @@
           pypy
           monolith
           nodejs
+          ocaml
+          opam
+          gmp
         ];
       };
     };


### PR DESCRIPTION
This PR adds "nyaya": an external checker for the Lean 4 export format written in OCaml. It is still a work-in-progress and fails four of the test cases in the arena which I hope to address in future revisions. This project was started in March of last year before any AI coding tools were as popular, but I did rely on them quite heavily towards the end for several performance optimizations and to debug failures when checking Init.lean. Please let me know if the PR needs any changes, as it seems to build and run fine on my local machine. 