### PR TITLE
feat: add zignodamus checker

### DIFF
--- a/checkers/just-another-kernel.yaml
+++ b/checkers/just-another-kernel.yaml
@@ -1,0 +1,16 @@
+description: |
+  Zig kernel based on [sokonanoda](https://github.com/intgrah/sokonanoda)
+url: https://github.com/intgrah/just-another-kernel
+ref: master
+rev: 8eb0b40781eead83f72549946045ba2bc51c2bff
+build: |
+  zig build -Doptimize=ReleaseFast
+run: |
+  ./zig-out/bin/just_another_kernel \
+    --use-stdin \
+    --nat-extension \
+    --string-extension \
+    --unsafe-permit-all-axioms \
+    --no-unpermitted-axiom-hard-error \
+    -j4 \
+    < "$IN" || exit 1

--- a/checkers/zignodamus.yaml
+++ b/checkers/zignodamus.yaml
@@ -2,7 +2,7 @@ description: |
   Zig kernel based on [sokonanoda](https://github.com/intgrah/sokonanoda)
 url: https://github.com/intgrah/just-another-kernel
 ref: master
-rev: 8eb0b40781eead83f72549946045ba2bc51c2bff
+rev: c64d5bfb3d460c38b295ecb318bf551eaec71a65
 build: |
   zig build -Doptimize=ReleaseFast
 run: |

--- a/checkers/zignodamus.yaml
+++ b/checkers/zignodamus.yaml
@@ -1,12 +1,12 @@
 description: |
   Zig kernel based on [sokonanoda](https://github.com/intgrah/sokonanoda)
-url: https://github.com/intgrah/just-another-kernel
+url: https://github.com/intgrah/zignodamus
 ref: master
 rev: c64d5bfb3d460c38b295ecb318bf551eaec71a65
 build: |
   zig build -Doptimize=ReleaseFast
 run: |
-  ./zig-out/bin/just_another_kernel \
+  ./zig-out/bin/zignodamus \
     --use-stdin \
     --nat-extension \
     --string-extension \

--- a/checkers/zignodamus.yaml
+++ b/checkers/zignodamus.yaml
@@ -2,7 +2,7 @@ description: |
   Zig kernel based on [sokonanoda](https://github.com/intgrah/sokonanoda)
 url: https://github.com/intgrah/zignodamus
 ref: master
-rev: c64d5bfb3d460c38b295ecb318bf551eaec71a65
+rev: 22a5795a2715fdf6ce429bfb9adb1cec87b6b0ba
 build: |
   zig build -Doptimize=ReleaseFast
 run: |

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           ocaml
           opam
           gmp
+          zig
         ];
       };
     };


### PR DESCRIPTION
Written in zig, about 7.2 minutes on mathlib.
Still explodes on cedar for the reason that it's the same algorithm as sokonanoda.

