### PR TITLE
test: proof irrelevance over structural equality

### DIFF
--- a/tests/proof-irrel.lean
+++ b/tests/proof-irrel.lean
@@ -1,0 +1,7 @@
+axiom A : Type
+axiom a : A
+axiom b : A
+axiom P : Prop
+axiom Q : P → Prop
+axiom foo : ∀ h : A → P, Q (h b)
+theorem bar : ∀ h : A → P, Q (h a) := foo

--- a/tests/proof-irrel.yaml
+++ b/tests/proof-irrel.yaml
@@ -1,0 +1,14 @@
+description: |
+  Incompleteness test for proof irrelevance under a binder.
+
+  `bar : ∀ h : A → P, Q (h a) := foo` where `foo : ∀ h : A → P, Q (h b)`.
+  Checking the assignment needs `Q (h a) ≡ Q (h b)`, i.e. `h a ≡ h b`. Both
+  `h a` and `h b` are proofs of the same `Prop` `P`, so they are definitionally
+  equal by proof irrelevance and a complete kernel accepts.
+
+  A checker that fails to apply proof irrelevance here — comparing `h a` and
+  `h b` structurally and finding the arguments `a` and `b` distinct — wrongly
+  rejects a valid proof.
+leanfile: tests/proof-irrel.lean
+export-decls: ["bar"]
+outcome: accept


### PR DESCRIPTION
It is an incompleteness bug in sokonanoda and zignodamus currently.

`bar : ∀ h : A → P, Q (h a)` and `foo : ∀ h : A → P, Q (h b)` should be convertible when `h : A -> P` and `P : Prop`, because of proof irrelevance.

