### PR TITLE
chore: bump zignodamus rev

### DIFF
--- a/checkers/zignodamus.yaml
+++ b/checkers/zignodamus.yaml
@@ -2,7 +2,7 @@ description: |
   Zig kernel based on [sokonanoda](https://github.com/intgrah/sokonanoda)
 url: https://github.com/intgrah/zignodamus
 ref: master
-rev: 6d7e4402220a30176950d85649466493b19caa01
+rev: 045df24df33d3be976f9cf7cbb9f79b3f62e9dea
 threads: 4
 build: |
   zig build -Drelease

--- a/checkers/zignodamus.yaml
+++ b/checkers/zignodamus.yaml
@@ -2,7 +2,7 @@ description: |
   Zig kernel based on [sokonanoda](https://github.com/intgrah/sokonanoda)
 url: https://github.com/intgrah/zignodamus
 ref: master
-rev: c43332f043a6fe8f946348d3ce69ef33c26e845d
+rev: a16ed4032885c9acb9bad81d181200cd083bfd1d
 build: |
   zig build -Drelease
 run: |

--- a/checkers/zignodamus.yaml
+++ b/checkers/zignodamus.yaml
@@ -2,7 +2,7 @@ description: |
   Zig kernel based on [sokonanoda](https://github.com/intgrah/sokonanoda)
 url: https://github.com/intgrah/zignodamus
 ref: master
-rev: a16ed4032885c9acb9bad81d181200cd083bfd1d
+rev: 045df24df33d3be976f9cf7cbb9f79b3f62e9dea
 build: |
   zig build -Drelease
 run: |


### PR DESCRIPTION
oops I git reset force push one too many which is why the last CI failed to find rev

