### PR TITLE
test: soundness bug (non-structure projection) in nanoda and descendants

### DIFF
--- a/tests/proj-non-structure.lean
+++ b/tests/proj-non-structure.lean
@@ -5,12 +5,13 @@ inductive Bad : Prop
   | mk1 : False → Bad
   | mk2 : True → Bad
 
-run_meta
+run_cmd liftTermElabM do
+  let bad : Expr := .proj `Bad 0 (mkApp (mkConst ``Bad.mk2) (mkConst ``True.intro))
+  let decl : Declaration := .thmDecl {
+      name := `bad
+      levelParams := []
+      type := mkConst ``False
+      value := bad
+    }
   withOptions (debug.skipKernelTC.set · true) do
-    addDecl <|
-      .thmDecl {
-        name := `bad
-        levelParams := []
-        type := mkConst ``False
-        value := .proj `Bad 0 (mkApp (mkConst ``Bad.mk2) (mkConst ``True.intro))
-      }
+    addDecl decl

--- a/tests/proj-non-structure.lean
+++ b/tests/proj-non-structure.lean
@@ -5,12 +5,12 @@ inductive Bad : Prop
   | mk1 : False → Bad
   | mk2 : True → Bad
 
-run_cmd liftTermElabM do
-  let decl : Declaration := .thmDecl {
-    name        := `bad
-    levelParams := []
-    type        := mkConst ``False
-    value       := .proj `Bad 0 (mkApp (mkConst ``Bad.mk2) (mkConst ``True.intro))
-  }
+run_meta
   withOptions (debug.skipKernelTC.set · true) do
-    addDecl decl
+    addDecl <|
+      .thmDecl {
+        name := `bad
+        levelParams := []
+        type := mkConst ``False
+        value := .proj `Bad 0 (mkApp (mkConst ``Bad.mk2) (mkConst ``True.intro))
+      }

--- a/tests/proj-non-structure.lean
+++ b/tests/proj-non-structure.lean
@@ -1,0 +1,16 @@
+import Lean
+open Lean Elab Command
+
+inductive Bad : Prop
+  | mk1 : False → Bad
+  | mk2 : True → Bad
+
+run_cmd liftTermElabM do
+  let decl : Declaration := .thmDecl {
+    name        := `bad
+    levelParams := []
+    type        := mkConst ``False
+    value       := .proj `Bad 0 (mkApp (mkConst ``Bad.mk2) (mkConst ``True.intro))
+  }
+  withOptions (debug.skipKernelTC.set · true) do
+    addDecl decl

--- a/tests/proj-non-structure.yaml
+++ b/tests/proj-non-structure.yaml
@@ -1,0 +1,7 @@
+description: |
+  `Bad` has two constructors, so projections should not be allowed.
+  Prove false by using the second constructor, then projecting, hoping that the
+  first constructor is used when inferring the type of the projection.
+leanfile: tests/proj-non-structure.lean
+export-decls: ["bad"]
+outcome: reject


### PR DESCRIPTION
The schematic version of the code looks like

```lean
inductive Bad : Prop
  | mk1 : False → Bad
  | mk2 : True → Bad

theorem bad : False := (Bad.mk2 True.intro).1
```
This is representable in the export format, and Lean code if you use metaprogramming.

```lean
import Lean
open Lean Elab Command

inductive Bad : Prop
  | mk1 : False → Bad
  | mk2 : True → Bad

run_cmd liftTermElabM do
  let bad : Expr := .proj `Bad 0 (mkApp (mkConst ``Bad.mk2) (mkConst ``True.intro))
  let decl : Declaration := .thmDecl {
      name := `bad
      levelParams := []
      type := mkConst ``False
      value := bad
    }
  withOptions (debug.skipKernelTC.set · true) do
    addDecl decl
```

<details>
<summary>Export</summary>

```json
{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"f72c35b3f637c8c6571d353742168ab66cc22c00","version":"4.29.1"}}}
{"in":1,"str":{"pre":0,"str":"False"}}
{"ie":0,"sort":0}
{"in":2,"str":{"pre":1,"str":"rec"}}
{"in":3,"str":{"pre":0,"str":"u"}}
{"il":1,"param":3}
{"in":4,"str":{"pre":0,"str":"motive"}}
{"in":5,"str":{"pre":0,"str":"t"}}
{"const":{"name":1,"us":[]},"ie":1}
{"ie":2,"sort":1}
{"forallE":{"binderInfo":"default","body":2,"name":5,"type":1},"ie":3}
{"bvar":1,"ie":4}
{"bvar":0,"ie":5}
{"app":{"arg":5,"fn":4},"ie":6}
{"forallE":{"binderInfo":"default","body":6,"name":5,"type":1},"ie":7}
{"forallE":{"binderInfo":"default","body":7,"name":4,"type":3},"ie":8}
{"inductive":{"ctors":[],"recs":[{"all":[1],"isUnsafe":false,"k":false,"levelParams":[3],"name":2,"numIndices":0,"numMinors":0,"numMotives":1,"numParams":0,"rules":[],"type":8}],"types":[{"all":[1],"ctors":[],"isRec":false,"isReflexive":false,"isUnsafe":false,"levelParams":[],"name":1,"numIndices":0,"numNested":0,"numParams":0,"type":0}]}}
{"in":6,"str":{"pre":0,"str":"True"}}
{"in":7,"str":{"pre":6,"str":"intro"}}
{"const":{"name":6,"us":[]},"ie":9}
{"in":8,"str":{"pre":6,"str":"rec"}}
{"forallE":{"binderInfo":"default","body":2,"name":5,"type":9},"ie":10}
{"in":9,"str":{"pre":0,"str":"intro"}}
{"const":{"name":7,"us":[]},"ie":11}
{"app":{"arg":11,"fn":5},"ie":12}
{"bvar":2,"ie":13}
{"app":{"arg":5,"fn":13},"ie":14}
{"forallE":{"binderInfo":"default","body":14,"name":5,"type":9},"ie":15}
{"forallE":{"binderInfo":"default","body":15,"name":9,"type":12},"ie":16}
{"forallE":{"binderInfo":"implicit","body":16,"name":4,"type":10},"ie":17}
{"ie":18,"lam":{"binderInfo":"default","body":5,"name":9,"type":12}}
{"ie":19,"lam":{"binderInfo":"default","body":18,"name":4,"type":10}}
{"inductive":{"ctors":[{"cidx":0,"induct":6,"isUnsafe":false,"levelParams":[],"name":7,"numFields":0,"numParams":0,"type":9}],"recs":[{"all":[6],"isUnsafe":false,"k":true,"levelParams":[3],"name":8,"numIndices":0,"numMinors":1,"numMotives":1,"numParams":0,"rules":[{"ctor":7,"nfields":0,"rhs":19}],"type":17}],"types":[{"all":[6],"ctors":[7],"isRec":false,"isReflexive":false,"isUnsafe":false,"levelParams":[],"name":6,"numIndices":0,"numNested":0,"numParams":0,"type":0}]}}
{"in":10,"str":{"pre":0,"str":"Bad"}}
{"in":11,"str":{"pre":10,"str":"mk1"}}
{"in":12,"str":{"pre":10,"str":"mk2"}}
{"in":13,"str":{"pre":0,"str":"a"}}
{"in":14,"str":{"pre":13,"str":"_@"}}
{"in":15,"str":{"pre":14,"str":"_internal"}}
{"in":16,"str":{"pre":15,"str":"_hyg"}}
{"in":17,"num":{"i":0,"pre":16}}
{"const":{"name":10,"us":[]},"ie":20}
{"forallE":{"binderInfo":"default","body":20,"name":17,"type":1},"ie":21}
{"forallE":{"binderInfo":"default","body":20,"name":17,"type":9},"ie":22}
{"in":18,"str":{"pre":10,"str":"rec"}}
{"forallE":{"binderInfo":"default","body":0,"name":5,"type":20},"ie":23}
{"in":19,"str":{"pre":0,"str":"mk1"}}
{"const":{"name":11,"us":[]},"ie":24}
{"app":{"arg":5,"fn":24},"ie":25}
{"app":{"arg":25,"fn":4},"ie":26}
{"forallE":{"binderInfo":"default","body":26,"name":17,"type":1},"ie":27}
{"in":20,"str":{"pre":0,"str":"mk2"}}
{"const":{"name":12,"us":[]},"ie":28}
{"app":{"arg":5,"fn":28},"ie":29}
{"app":{"arg":29,"fn":13},"ie":30}
{"forallE":{"binderInfo":"default","body":30,"name":17,"type":9},"ie":31}
{"bvar":3,"ie":32}
{"app":{"arg":5,"fn":32},"ie":33}
{"forallE":{"binderInfo":"default","body":33,"name":5,"type":20},"ie":34}
{"forallE":{"binderInfo":"default","body":34,"name":20,"type":31},"ie":35}
{"forallE":{"binderInfo":"default","body":35,"name":19,"type":27},"ie":36}
{"forallE":{"binderInfo":"implicit","body":36,"name":4,"type":23},"ie":37}
{"ie":38,"lam":{"binderInfo":"default","body":14,"name":17,"type":1}}
{"ie":39,"lam":{"binderInfo":"default","body":38,"name":20,"type":31}}
{"ie":40,"lam":{"binderInfo":"default","body":39,"name":19,"type":27}}
{"ie":41,"lam":{"binderInfo":"default","body":40,"name":4,"type":23}}
{"ie":42,"lam":{"binderInfo":"default","body":6,"name":17,"type":9}}
{"ie":43,"lam":{"binderInfo":"default","body":42,"name":20,"type":31}}
{"ie":44,"lam":{"binderInfo":"default","body":43,"name":19,"type":27}}
{"ie":45,"lam":{"binderInfo":"default","body":44,"name":4,"type":23}}
{"inductive":{"ctors":[{"cidx":0,"induct":10,"isUnsafe":false,"levelParams":[],"name":11,"numFields":1,"numParams":0,"type":21},{"cidx":1,"induct":10,"isUnsafe":false,"levelParams":[],"name":12,"numFields":1,"numParams":0,"type":22}],"recs":[{"all":[10],"isUnsafe":false,"k":false,"levelParams":[],"name":18,"numIndices":0,"numMinors":2,"numMotives":1,"numParams":0,"rules":[{"ctor":11,"nfields":1,"rhs":41},{"ctor":12,"nfields":1,"rhs":45}],"type":37}],"types":[{"all":[10],"ctors":[11,12],"isRec":false,"isReflexive":false,"isUnsafe":false,"levelParams":[],"name":10,"numIndices":0,"numNested":0,"numParams":0,"type":0}]}}
{"in":21,"str":{"pre":0,"str":"bad"}}
{"app":{"arg":11,"fn":28},"ie":46}
{"ie":47,"proj":{"idx":0,"struct":46,"typeName":10}}
{"thm":{"all":[21],"levelParams":[],"name":21,"type":1,"value":47}}
```
</details>

The bug is forgetting to check that the inductive has more than 1 constructor, which can happen if you blindly trust the convenience data in the export format.
In this case, projection used the 0th constructor to infer the type.
