### PR TITLE
Decline Mathlib when running rpylean

### DIFF
--- a/checkers/rpylean.yaml
+++ b/checkers/rpylean.yaml
@@ -1,6 +1,10 @@
 version: "v2026.7.6"
 description: |
   **rpylean** - A Lean type checker written in (R)Python.
+
+  Mathlib is **declined** (exit 2) rather than run: rpylean does not check it
+  successfully yet, and the attempt costs about an hour per arena run for an
+  already-known outcome.
 url: https://github.com/Julian/rpylean
 ref: main
 rev: 1f6d2205d3958484b7de351d314a5e02896b9fab
@@ -11,4 +15,10 @@ build: |
   __END__
   just translate
 run: |
+  # rpylean does not pass on Mathlib yet, so decline it (exit 2) instead of
+  # spending an hour of the run to learn what we already know. $IN is
+  # _build/tests/<test-name>.ndjson.
+  case "${IN##*/}" in
+    mathlib.ndjson) exit 2 ;;
+  esac
   ./rpylean-c check "$IN" || exit 1


### PR DESCRIPTION
rpylean doesn't pass on Mathlib yet, so running it costs about an hour per arena run for an already-known outcome.

Exit 2 (decline) is the framework's signal for this — it's ignored for completeness and correctness scoring, and unlike a reject it makes no claim that Mathlib's proofs are invalid. The guard keys on `$IN`'s basename (`_build/tests/<test-name>.ndjson`) and precedes the checker invocation, so nothing is spent on that test.

Worth noting: this is filename-keyed, so renaming `tests/mathlib.yaml` would silently disable it. There's no way to express "checker X skips test Y" in the schema today; `skip-on-ci` is a property of the test and applies to every checker.

[#general > Lean Kernel Arena @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Lean.20Kernel.20Arena/near/613012208)

🤖 Generated with [Claude Code](https://claude.com/claude-code)