### PR TITLE
test: non-uniform parameter in nested inductive occurrence

### DIFF
--- a/lka.py
+++ b/lka.py
@@ -1227,6 +1227,10 @@ def run_checker_on_test(checker: dict, test: dict, build_dir: Path, tests_dir: P
         correctness = "declined"
     elif status == "error":
         correctness = "error"
+    elif expected_outcome == "either":
+        # Not settled whether a checker should accept or reject this: both
+        # behaviours are acceptable. Excluded from the scoring columns.
+        correctness = "either"
     elif expected_outcome == "accept" and status == "accepted":
         correctness = "correct"
     elif expected_outcome == "reject" and status == "rejected":
@@ -1329,6 +1333,8 @@ def cmd_run_checker(args: argparse.Namespace) -> int:
                 correctness_emoji = '❌'
             elif correctness == 'declined':
                 correctness_emoji = '⊘'
+            elif correctness == 'either':
+                correctness_emoji = '🤷'
             else:  # error
                 correctness_emoji = '⚠️'
             
@@ -1339,19 +1345,21 @@ def cmd_run_checker(args: argparse.Namespace) -> int:
     print("Summary:")
     print("=" * 60)
 
-    correctness_counts = {"correct": 0, "incorrect": 0, "declined": 0, "error": 0}
+    correctness_counts = {"correct": 0, "incorrect": 0, "either": 0, "declined": 0, "error": 0}
     for r in results:
         correctness = r.get("correctness", "error")
         correctness_counts[correctness] = correctness_counts.get(correctness, 0) + 1
 
-    # Print in order: correct, incorrect, declined, error
-    for correctness in ["correct", "incorrect", "declined", "error"]:
+    # Print in order: correct, incorrect, either, declined, error
+    for correctness in ["correct", "incorrect", "either", "declined", "error"]:
         count = correctness_counts.get(correctness, 0)
         if count > 0:
             if correctness == "correct":
                 emoji = "✅"
             elif correctness == "incorrect":
                 emoji = "❌"
+            elif correctness == "either":
+                emoji = "🤷"
             elif correctness == "declined":
                 emoji = "⊘"
             else:  # error
@@ -1484,6 +1492,11 @@ def compute_checker_stats(checker: dict, tests: list[dict], results: dict) -> di
         # Errors don't make any assertion about correctness, so treat them like declines
         if status == "declined" or status == "error":
             declined_count += 1
+            continue
+
+        # 'either' tests have no settled expected outcome, so they are excluded
+        # from the completeness and soundness columns (neither behaviour counts).
+        if expected_outcome == "either":
             continue
 
         if expected_outcome == "accept":
@@ -1640,9 +1653,13 @@ def create_test_tarball(tests: list, output_dir: Path) -> dict:
             if outcome == "accept":
                 subdir = "good"
                 good_count += 1
-            else:
+            elif outcome == "reject":
                 subdir = "bad"
                 bad_count += 1
+            else:
+                # 'either' (and any unclassified) tests have no expected good/bad
+                # bucket, so they are not included in the downloadable tarball.
+                continue
 
             # Add file to tarball with appropriate subdirectory
             arcname = f"{subdir}/{test['name']}.ndjson"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -60,7 +60,7 @@ Validates checker configuration files in the `checkers/` directory.
 - `module`: Lean module name to export using lean4export
 - `run`: Shell command to generate test data (`$OUT` variable available)
 - `pre-build`: Command to run before building (e.g., `lake exe cache get`)
-- `outcome`: Expected test result (`"accept"` or `"reject"`)
+- `outcome`: Expected test result (`"accept"`, `"reject"`, or `"either"`). Use `"either"` for tests where it is not (yet) settled whether a checker should accept or reject; both behaviours count as acceptable, and the test is excluded from the completeness and soundness columns.
 
 ### Checker-Specific Fields
 - `build`: Shell command to build the checker (optional - only needed if compilation is required)

--- a/schemas/test.json
+++ b/schemas/test.json
@@ -54,8 +54,8 @@
     },
     "outcome": {
       "type": "string",
-      "enum": ["accept", "reject"],
-      "description": "Expected test outcome for correctness checking"
+      "enum": ["accept", "reject", "either"],
+      "description": "Expected test outcome for correctness checking. Use 'either' for tests where it is not (yet) settled whether a checker should accept or reject: both behaviours are treated as acceptable, and the test is excluded from the completeness and soundness columns."
     },
     "compare-perf": {
       "type": "boolean",

--- a/templates/checker.html
+++ b/templates/checker.html
@@ -107,7 +107,7 @@ section pre, details pre {
                 <td><a href="#test-{{ result.test }}">{{ result.test }}</a></td>
                 <td class="spacer-col"></td>
                 <td class="text-center">
-                    {% if result.expected == 'accept' %}👍{% elif result.expected == 'reject' %}✋{% else %}⚠️ {{ result.expected }}{% endif %}
+                    {% if result.expected == 'accept' %}👍{% elif result.expected == 'reject' %}✋{% elif result.expected == 'either' %}🤷{% else %}⚠️ {{ result.expected }}{% endif %}
                 </td>
                 {{ result_status_cell(result.expected, result.status) }}
                 {{ perf_cells(result, result.expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time) }}
@@ -127,7 +127,7 @@ section pre, details pre {
 
     <p>
         <strong>Expected:</strong>
-        {% if result.expected == 'accept' %}👍 accept{% elif result.expected == 'reject' %}✋ reject{% else %}⚠️ {{ result.expected }}{% endif %}
+        {% if result.expected == 'accept' %}👍 accept{% elif result.expected == 'reject' %}✋ reject{% elif result.expected == 'either' %}🤷 either{% else %}⚠️ {{ result.expected }}{% endif %}
         {% if result.test_stats %}
         · <strong>Size:</strong> {{ result.test_stats.size_str }}
         · <strong>Lines:</strong> {{ result.test_stats.lines_str }}
@@ -155,7 +155,7 @@ section pre, details pre {
 
     <p>
       <b>Test result:</b>
-        <span class="{% if (result.expected == 'accept' and result.status == 'accepted') or (result.expected == 'reject' and result.status == 'rejected') %}bg-success{% elif (result.expected == 'accept' and result.status != 'accepted' and result.status != 'declined' and result.status != 'error') or (result.expected == 'reject' and result.status != 'rejected' and result.status != 'declined' and result.status != 'error') %}bg-error{% else %}bg-warning{% endif %}" style="padding: 0.2em 0.5em; border-radius: 3px;">
+        <span class="{% if result.expected == 'either' %}{% elif (result.expected == 'accept' and result.status == 'accepted') or (result.expected == 'reject' and result.status == 'rejected') %}bg-success{% elif (result.expected == 'accept' and result.status != 'accepted' and result.status != 'declined' and result.status != 'error') or (result.expected == 'reject' and result.status != 'rejected' and result.status != 'declined' and result.status != 'error') %}bg-error{% else %}bg-warning{% endif %}" style="padding: 0.2em 0.5em; border-radius: 3px;">
             {% if result.status == 'accepted' %}👍 accepted{% elif result.status == 'rejected' %}✋ rejected{% elif result.status == 'declined' %}🚫 declined{% else %}💥 {{ result.status }}{% endif %}
         </span>
         · exit code {{ result.exit_code }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,7 +131,7 @@ table thead th {
                     {% if checker.get('serious', true) and checker.name == 'official' %}
                     {% set key = (checker.name, test.name) %}
                     {% set result = test_results.get(key) %}
-                    <td class="text-center official-column {% if result %}{% if (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
+                    <td class="text-center official-column {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
                         {% if result %}
                         <a href="checker/{{ checker.name }}/#test-{{ test.name }}" style="text-decoration: none; color: inherit; display: block;">
                             {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
@@ -157,7 +157,7 @@ table thead th {
                     {% if checker.get('serious', true) and checker.name != 'official' %}
                     {% set key = (checker.name, test.name) %}
                     {% set result = test_results.get(key) %}
-                    <td class="text-center {% if result %}{% if (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
+                    <td class="text-center {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
                         {% if result %}
                         <a href="checker/{{ checker.name }}/#test-{{ test.name }}" style="text-decoration: none; color: inherit; display: block;">
                             {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
@@ -215,6 +215,10 @@ table thead th {
 
     <p>
         Checkers that do not implement all features may choose to explicitly decline to process certain tests (column 🚫). These tests are not taken into account for correctness scoring. Tests that crash the checker (💥) also considered declined.
+    </p>
+
+    <p>
+        Tests can come without an expected outcome (shown as 🤷). These test corner cases that are not known to be soundness relevant and not typically relevant in practice, and where it is acceptable for a checker to accept or to reject. They are excluded from the completeness and soundness scoring.
     </p>
 
     <p>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -22,7 +22,7 @@
 
 {# Result status cell with background color #}
 {% macro result_status_cell(expected, status) %}
-<td class="text-center {% if (expected == 'accept' and status == 'accepted') or (expected == 'reject' and status == 'rejected') %}{% elif status == 'declined' or status == 'error' %}bg-warning{% else %}bg-error{% endif %}">
+<td class="text-center {% if expected == 'either' %}{% elif (expected == 'accept' and status == 'accepted') or (expected == 'reject' and status == 'rejected') %}{% elif status == 'declined' or status == 'error' %}bg-warning{% else %}bg-error{% endif %}">
     {% if status == 'accepted' %}👍{% elif status == 'rejected' %}✋{% elif status == 'declined' %}🚫{% else %}💥{% endif %}
 </td>
 {% endmacro %}

--- a/templates/test.html
+++ b/templates/test.html
@@ -19,7 +19,7 @@
     </header>
     <p>
         <strong>Expected:</strong>
-        {% if test.outcome == 'accept' %}👍 accept{% elif test.outcome == 'reject' %}✋ reject{% else %}⚠️ {{ test.outcome }}{% endif %}
+        {% if test.outcome == 'accept' %}👍 accept{% elif test.outcome == 'reject' %}✋ reject{% elif test.outcome == 'either' %}🤷 either{% else %}⚠️ {{ test.outcome }}{% endif %}
         · <strong>Size:</strong> {{ test.size_str }}
         · <strong>Lines:</strong> {{ test.lines_str }}
         {% if test.lean4export_version %}

--- a/tests/nested-nonuniform-param.lean
+++ b/tests/nested-nonuniform-param.lean
@@ -1,0 +1,24 @@
+import Lean
+open Lean Elab Command
+
+inductive W : Type where | mk (p : Bool)
+inductive L (α : Type) : Type where | mk
+
+meta def build : CommandElabM Unit := do
+  -- Skip the kernel type-check so test generation still produces the export
+  -- even on a toolchain whose kernel rejects the malformed declaration.
+  let add (d : Declaration) : CommandElabM Unit :=
+    liftCoreM <| withOptions (debug.skipKernelTC.set · true) <| addDecl d
+  let Ef := mkApp (mkConst `E) (mkApp (mkConst ``W.mk) (mkConst ``false))
+  let l := mkApp (mkConst ``L) Ef
+  let Et := mkForall `w .default (mkConst ``W) (mkSort 1)
+  -- E.mk : (w : W) → L (E ⟨false⟩) → E w
+  -- The nested occurrence `L (E ⟨false⟩)` uses the constant `⟨false⟩` where the
+  -- parameter `w` should be; `⟨false⟩` is type-correct but is not the parameter.
+  let ct := mkForall `w .default (mkConst ``W) <|
+    mkForall `l .default l (mkApp (mkConst `E) (mkBVar 1))
+  add <| .inductDecl [] 1 [{
+    name := `E, type := Et, ctors := [{ name := `E.mk, type := ct }] }] false
+
+elab "mkbug" : command => build
+mkbug

--- a/tests/nested-nonuniform-param.yaml
+++ b/tests/nested-nonuniform-param.yaml
@@ -12,17 +12,18 @@ description: |
   nested application (leanprover/lean4#14577); a correct checker must also
   verify that it is the expected parameter.
 
-  Note this particular declaration is not known to yield a proof of `False`:
-  here `L` stores no value of type `α`, so the nested occurrence is phantom and
-  `E w` is isomorphic to `Unit` for every `w`. The variant where `L` actually
-  stores an `α` (so recursion would descend into an `E ⟨false⟩` while the motive
-  is fixed at `E w`) is already rejected by the kernel's positivity check
-  ("non valid occurrence"). This test therefore guards a well-formedness /
-  defense-in-depth condition rather than a demonstrated inconsistency.
+  This particular declaration is not known to yield a proof of `False`: here `L`
+  stores no value of type `α`, so the nested occurrence is phantom and `E w` is
+  isomorphic to `Unit` for every `w`. The variant where `L` actually stores an
+  `α` (so recursion would descend into an `E ⟨false⟩` while the motive is fixed
+  at `E w`) is already rejected by the kernel's positivity check ("non valid
+  occurrence"). Since it is not a demonstrated unsoundness, it is not settled
+  whether a checker should accept or reject it, so the expected outcome is
+  `either` and the test does not count towards completeness or soundness.
 
   Origin: raised by @arthur-adjedj on leanprover/lean4#14577
   (https://github.com/leanprover/lean4/pull/14577#issuecomment-5101819377) as a
   case not covered by that PR's fix; related to leanprover/lean4#14576.
 leanfile: tests/nested-nonuniform-param.lean
 export-decls: ["E"]
-outcome: reject
+outcome: either

--- a/tests/nested-nonuniform-param.yaml
+++ b/tests/nested-nonuniform-param.yaml
@@ -1,0 +1,28 @@
+description: |
+  Checks that a parameter supplied to a nested inductive occurrence really acts
+  as the datatype's parameter, i.e. that it is the parameter itself and does not
+  change between recursive occurrences (as is already enforced for non-nested
+  occurrences).
+
+  The inductive `E : W → Type` has constructor
+  `E.mk : (w : W) → L (E ⟨false⟩) → E w`, where `L (α : Type)` is nested. The
+  occurrence `E ⟨false⟩` inside the nested `L` uses the constant `⟨false⟩` in
+  the position of `E`'s parameter, instead of the actual parameter `w`. That
+  argument is type-correct, so it is not caught by merely type-checking the
+  nested application (leanprover/lean4#14577); a correct checker must also
+  verify that it is the expected parameter.
+
+  Note this particular declaration is not known to yield a proof of `False`:
+  here `L` stores no value of type `α`, so the nested occurrence is phantom and
+  `E w` is isomorphic to `Unit` for every `w`. The variant where `L` actually
+  stores an `α` (so recursion would descend into an `E ⟨false⟩` while the motive
+  is fixed at `E w`) is already rejected by the kernel's positivity check
+  ("non valid occurrence"). This test therefore guards a well-formedness /
+  defense-in-depth condition rather than a demonstrated inconsistency.
+
+  Origin: raised by @arthur-adjedj on leanprover/lean4#14577
+  (https://github.com/leanprover/lean4/pull/14577#issuecomment-5101819377) as a
+  case not covered by that PR's fix; related to leanprover/lean4#14576.
+leanfile: tests/nested-nonuniform-param.lean
+export-decls: ["E"]
+outcome: reject


### PR DESCRIPTION
Adds a test for a nested inductive whose nested occurrence supplies a
constant (`⟨false⟩`) where the datatype's parameter should be, instead of
the parameter itself. The argument is type-correct, so it is not caught by
type-checking the nested application (leanprover/lean4#14577); a correct
checker must additionally verify the parameter actually acts as one.

Raised by @arthur-adjedj on leanprover/lean4#14577; related to
leanprover/lean4#14576.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D6eedjfpntSKyEKsNPBxb3
