### PR TITLE
Add declarative `declines` field to checker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ The `run` command receives the test file path via the `$IN` environment variable
   
 - anything else: an error in the checker
 
+If it is already known that a checker cannot handle a test, and running it would just waste time, the checker YAML can list that test in the `declines` field (a test name or list of test names). Such tests are recorded as declined without running the checker at all.
+
 The arena does not automatically update the checkers; please submit new releases manually.
 
 ## Fair Play

--- a/checkers/rpylean.yaml
+++ b/checkers/rpylean.yaml
@@ -12,3 +12,6 @@ build: |
   just translate
 run: |
   ./rpylean-c check "$IN" || exit 1
+# rpylean does not pass on Mathlib yet; running it costs about an hour per
+# arena run for an already-known outcome.
+declines: mathlib

--- a/lka.py
+++ b/lka.py
@@ -621,6 +621,10 @@ def load_test_descriptions() -> list[dict]:
 def load_checkers() -> list[dict]:
     """Load all checker definitions, filtering out disabled ones."""
     all_checkers = load_yaml_files(get_project_root() / "checkers", "checker")
+    for checker in all_checkers:
+        # Normalize `declines` (a single test name or a list) to a list
+        declines = checker.get("declines", [])
+        checker["declines"] = [declines] if isinstance(declines, str) else declines
     # Filter out disabled checkers
     return [checker for checker in all_checkers if not checker.get("disable", False)]
 
@@ -1168,6 +1172,28 @@ def run_checker_on_test(checker: dict, test: dict, build_dir: Path, tests_dir: P
     checker_name = checker["name"]
     test_name = test["name"]
     checker_run_cmd = checker["run"]
+
+    # Tests listed in the checker's `declines` are declined without running
+    if test_name in checker.get("declines", []):
+        result_data = {
+            "checker": checker_name,
+            "test": test_name,
+            "status": "declined",
+            "correctness": "declined",
+            "exit_code": 2,
+            "wall_time": 0,
+            "cpu_time": 0,
+            "max_rss": 0,
+            "instructions": 0,
+            "stdout": "",
+            "stderr": "Declined via the `declines` field in the checker configuration; the checker was not run.",
+        }
+        results_dir.mkdir(parents=True, exist_ok=True)
+        safe_test_name = test_name.replace("/", "_")
+        result_file = results_dir / f"{checker_name}_{safe_test_name}.json"
+        with open(result_file, "w") as f:
+            json.dump(result_data, f, indent=2)
+        return result_data
 
     # Use the file path stored in the test dict
     test_file = test["file"]

--- a/schemas/checker.json
+++ b/schemas/checker.json
@@ -43,6 +43,17 @@
       "type": "boolean",
       "description": "If true, this checker will be ignored and not built or run"
     },
+    "declines": {
+      "description": "Test name or list of test names that this checker declines without running them (recorded as declined, as if the checker had exited with code 2)",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        }
+      ]
+    },
     "serious": {
       "type": "boolean",
       "description": "If false, this checker is omitted from the main comparison tables (default: true)"


### PR DESCRIPTION
A checker YAML can now list test names (a single name or a list) that it
declines up front: the test is recorded as declined (as if the checker
had exited with code 2) without running the checker at all.

Use this to have rpylean decline mathlib, which costs about an hour per
arena run for an already-known outcome.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D6eedjfpntSKyEKsNPBxb3
