### PR TITLE
test: undecidability

### DIFF
--- a/tests/undecidability/alg-conv-trans-acc-left.yaml
+++ b/tests/undecidability/alg-conv-trans-acc-left.yaml
@@ -1,0 +1,9 @@
+description: |
+  The creative half of `undecidability/alg-conv-trans-acc`. `Acc.rec` is stuck
+  on the variable `a`, and proof irrelevance admits any other proof of
+  `Acc (· < ·) 1` in its place, including one with a constructor at the head.
+  Given both sides, a checker verifies this immediately; producing the
+  right-hand side unprompted is the step no algorithm takes.
+leanfile: tests/undecidability/alg-conv.lean
+export-decls: ["left"]
+outcome: accept

--- a/tests/undecidability/alg-conv-trans-acc-right.yaml
+++ b/tests/undecidability/alg-conv-trans-acc-right.yaml
@@ -1,0 +1,7 @@
+description: |
+  The mechanical half of `undecidability/alg-conv-trans-acc`. With a
+  constructor in the major premise, `Acc.rec` fires and `step` descends to the
+  predecessor `0`.
+leanfile: tests/undecidability/alg-conv.lean
+export-decls: ["right"]
+outcome: accept

--- a/tests/undecidability/alg-conv-trans-acc.yaml
+++ b/tests/undecidability/alg-conv-trans-acc.yaml
@@ -1,0 +1,24 @@
+description: |
+  As Lean's type theory has undecidable conversion (a.k.a. definitional equality),
+  there are bound to be gaps between so called "algorithmic" conversion (that which is
+  implemented by a typechecker), and the "declarative" conversion.
+
+  In the official kernel, algorithmic conversion fails to be transitive. `f 1 a`
+  is a normal form: `a` is a variable, so `Acc.rec` cannot fire on it. Proof
+  irrelevance admits any other proof of `Acc (· < ·) 1` in its place, and
+  `Acc.intro 1 fun _ => Acc.inv a` carries a constructor at the head, so it
+  reduces. `left` is that substitution, `right` the reduction it unblocks, and
+  `trans` chains the two.
+
+  `acc` asks for the endpoints on their own, which means inventing the middle
+  term: choosing, among the proofs of a proposition, the one that happens to
+  reduce the right way. The kernel has no reason to go looking, the left side
+  being normal already, and unfolding regardless does not terminate here, as
+  each step makes the term larger.
+
+  References:
+
+  - Mario Carneiro, *The Type Theory of Lean*, MSc thesis
+leanfile: tests/undecidability/alg-conv.lean
+export-decls: ["trans"]
+outcome: either

--- a/tests/undecidability/alg-conv-trans-quot-left-def.yaml
+++ b/tests/undecidability/alg-conv-trans-quot-left-def.yaml
@@ -1,0 +1,6 @@
+description: |
+  `left` with `Quot.lift` behind a definition. WHNF does not unfold `lift`, so
+  the arguments are compared and proof irrelevance applies.
+leanfile: tests/undecidability/alg-conv-trans-quot.lean
+export-decls: ["left'"]
+outcome: either

--- a/tests/undecidability/alg-conv-trans-quot-left.yaml
+++ b/tests/undecidability/alg-conv-trans-quot-left.yaml
@@ -1,0 +1,7 @@
+description: |
+  `Quot r` is a `Prop`, so proof irrelevance relates `q` and `Quot.mk r z`.
+  However the official kernel does WHNF first, reducing the right side to `f z`,
+  so congruence never compares the arguments.
+leanfile: tests/undecidability/alg-conv-trans-quot.lean
+export-decls: ["left"]
+outcome: either

--- a/tests/undecidability/alg-conv-trans-quot-right.yaml
+++ b/tests/undecidability/alg-conv-trans-quot-right.yaml
@@ -1,0 +1,5 @@
+description: |
+  Quotient computation rule.
+leanfile: tests/undecidability/alg-conv-trans-quot.lean
+export-decls: ["right"]
+outcome: accept

--- a/tests/undecidability/alg-conv-trans-quot.lean
+++ b/tests/undecidability/alg-conv-trans-quot.lean
@@ -1,0 +1,25 @@
+import Lean
+open Lean Meta Elab Tactic
+
+variable {P : Prop} {r : P → P → Prop}
+  {α : Sort 1} (f : P → α) (h : ∀ x y, r x y → f x = f y)
+  (q : Quot r) (z : P)
+
+set_option debug.skipKernelTC true in
+theorem left : Quot.lift f h q = Quot.lift f h (Quot.mk r z) := by
+  run_tac closeMainGoalUsing `bogus fun goalType _ => do
+    let some (_, lhs, _) := goalType.eq? | throwError "goal is not an equality"
+    mkEqRefl lhs
+
+def lift := @Quot.lift
+theorem left' : lift f h q = lift f h (Quot.mk r z) :=
+  rfl
+
+theorem right : Quot.lift f h (Quot.mk r z) = f z :=
+  rfl
+
+set_option debug.skipKernelTC true in
+theorem trans : Quot.lift f h q = f z := by
+  run_tac closeMainGoalUsing `bogus fun goalType _ => do
+    let some (_, lhs, _) := goalType.eq? | throwError "goal is not an equality"
+    mkEqRefl lhs

--- a/tests/undecidability/alg-conv-trans-quot.yaml
+++ b/tests/undecidability/alg-conv-trans-quot.yaml
@@ -1,0 +1,12 @@
+description: |
+  `left` composed with `right`. Quotients of propositions cause
+  algorithmic conversion transitivity to fail because the typechecker must
+  creatively synthesise the representative of the quotient, and
+  proof irrelevance is definitional.
+
+  References:
+
+  - Mario Carneiro, *The Type Theory of Lean*, MSc thesis
+leanfile: tests/undecidability/alg-conv-trans-quot.lean
+export-decls: ["trans"]
+outcome: either

--- a/tests/undecidability/alg-conv.lean
+++ b/tests/undecidability/alg-conv.lean
@@ -1,0 +1,47 @@
+import Lean
+open Lean Meta Elab Tactic
+
+def step (x : Nat) (ih : (y : Nat) → y < x → Bool) : Bool :=
+  match x with
+  | 0 => true
+  | k + 1 => ih k (Nat.lt_succ_self k)
+
+def f (n : Nat) (a : Acc (· < ·) n) : Bool :=
+  Acc.rec (fun x _ => step x) a
+
+variable (a : Acc (· < ·) 1)
+
+/-! Failure of algorithmic conversion transitivity -/
+
+theorem left :
+    f 1 a =
+    f 1 (Acc.intro 1 fun _ => Acc.inv a) :=
+  rfl
+
+theorem right :
+    f 1 (Acc.intro 1 fun _ => Acc.inv a) =
+    f 0 (Acc.inv a (Nat.lt_succ_self 0)) :=
+  rfl
+
+set_option debug.skipKernelTC true in
+theorem trans :
+    f 1 a =
+    f 0 (Acc.inv a (Nat.lt_succ_self 0)) := by
+  run_tac closeMainGoalUsing `bogus fun goalType _ => do
+    let some (_, lhs, _) := goalType.eq? | throwError "goal is not an equality"
+    mkEqRefl lhs
+
+/-! Failure of subject reduction -/
+
+def redex (D : Bool → Type)
+    (k : D (f 0 (Acc.inv a (Nat.lt_succ_self 0))) → Unit) (x0 : D (f 1 a)) : Unit :=
+  (fun y : D (f 1 (Acc.intro 1 fun _ => Acc.inv a)) => k y) x0
+
+set_option debug.skipKernelTC true in
+def reduct (D : Bool → Type)
+    (k : D (f 0 (Acc.inv a (Nat.lt_succ_self 0))) → Unit) (x0 : D (f 1 a)) : Unit := by
+  run_tac closeMainGoalUsing `bogus fun _ _ => do
+    let lctx ← getLCtx
+    let some kd := lctx.findFromUserName? `k | throwError "no k"
+    let some xd := lctx.findFromUserName? `x0 | throwError "no x0"
+    return mkApp kd.toExpr xd.toExpr

--- a/tests/undecidability/subject-reduction-redex.yaml
+++ b/tests/undecidability/subject-reduction-redex.yaml
@@ -1,0 +1,14 @@
+description: |
+  Test for subject reduction, as in Carneiro's thesis.
+
+  The annotation on the lambda writes the middle term of
+  `undecidability/alg-conv-trans-acc` down by hand, sparing the kernel from
+  having to invent it. The body checks against `right`, the argument against
+  `left`, and the two endpoints are never compared.
+
+  References:
+
+  - Mario Carneiro, *The Type Theory of Lean*, MSc thesis
+leanfile: tests/undecidability/alg-conv.lean
+export-decls: ["redex"]
+outcome: accept

--- a/tests/undecidability/subject-reduction-reduct.yaml
+++ b/tests/undecidability/subject-reduction-reduct.yaml
@@ -1,0 +1,12 @@
+description: |
+  Beta erases the annotation of `undecidability/subject-reduction-redex`, and
+  with it the middle term, leaving the two endpoints to compare: the conversion
+  of `undecidability/alg-conv-trans-acc`. A term the kernel accepts thus
+  reduces to one it rejects.
+
+  References:
+
+  - Mario Carneiro, *The Type Theory of Lean*, MSc thesis
+leanfile: tests/undecidability/alg-conv.lean
+export-decls: ["reduct"]
+outcome: either


### PR DESCRIPTION
Add tests for:

- Failure of transitivity of algorithmic conversion via Acc and Quot
- Failure of subject reduction

consisting of various `accept` and some `either` tests.

