### PR TITLE
ci: parallelize checkers via a GitHub Actions matrix

### DIFF
--- a/.github/checker-matrix.sh
+++ b/.github/checker-matrix.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Selects the checkers to run in CI and prints them as a "checkers=<JSON
+# array>" line, suitable for appending to $GITHUB_OUTPUT.
+#
+# Normally all enabled checkers are selected. On pull requests that touch
+# nothing but checker configurations, only the touched checkers are selected.
+set -euo pipefail
+
+all=$(uv run lka.py list-checkers --json)
+selected="$all"
+
+if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+  # Diff the PR head commit against its merge base with the target branch.
+  # BASE_SHA and HEAD_SHA are set from the event payload in the workflow;
+  # computing the merge base requires a full-history checkout.
+  changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+  if [ -n "$changed" ] && ! grep -qv '^checkers/[^/]*\.yaml$' <<< "$changed"; then
+    touched=$(sed -e 's!^checkers/!!' -e 's!\.yaml$!!' <<< "$changed" | jq --raw-input . | jq --slurp --compact-output .)
+    # Restrict to the touched checkers, as far as they (still) exist and are
+    # enabled. If none are left (e.g. the PR deletes a checker), fall back to
+    # running all of them.
+    selected=$(jq --compact-output --argjson touched "$touched" 'map(select(. as $c | $touched | index($c)))' <<< "$all")
+    if [ "$selected" = "[]" ]; then
+      selected="$all"
+    fi
+  fi
+fi
+
+echo "Selected checkers: $selected" >&2
+echo "checkers=$selected"

--- a/.github/checker-matrix.sh
+++ b/.github/checker-matrix.sh
@@ -6,7 +6,7 @@
 # nothing but checker configurations, only the touched checkers are selected.
 set -euo pipefail
 
-all=$(uv run lka.py list-checkers --json)
+all=$(./lka.py list-checkers --json)
 selected="$all"
 
 if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,12 +27,19 @@ jobs:
           # Full history, to compute the merge base of a pull request
           fetch-depth: 0
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v9
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup nix shell
+        run: "true"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Select checkers to run
         id: select
         run: .github/checker-matrix.sh >> "$GITHUB_OUTPUT"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -108,7 +108,7 @@ jobs:
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Stage results for upload
-        run: ./lka.py ci-pack --outdir /tmp/artifact
+        run: ./lka.py ci-pack --outdir /tmp/artifact --results
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Upload results
@@ -154,9 +154,53 @@ jobs:
           name: tutorial-page
           path: _out/tutorial
 
+  test-stats:
+    name: Build test stats and tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup nix shell
+        run: "true"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Generate tests
+        run: ./lka.py build-test ${{ github.event_name != 'workflow_dispatch' && '--skip-ci' || '' }}
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Build test tarball
+        run: ./lka.py build-tarball
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Stage test stats for upload
+        run: ./lka.py ci-pack --outdir /tmp/artifact --test-stats
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Upload test stats
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-stats
+          path: /tmp/artifact
+
+      - name: Upload test tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-tarball
+          path: _out/lean-arena-tests.tar.gz
+
   build-site:
     name: Build and deploy site
-    needs: [check, tutorial]
+    needs: [check, tutorial, test-stats]
     if: ${{ !cancelled() && needs.check.result != 'skipped' }}
     runs-on: ubuntu-latest
 
@@ -192,7 +236,13 @@ jobs:
           pattern: results-*
           path: _artifacts
 
-      - name: Merge checker results
+      - name: Fetch test stats
+        uses: actions/download-artifact@v8
+        with:
+          name: test-stats
+          path: _artifacts/test-stats
+
+      - name: Merge checker results and test stats
         run: ./lka.py ci-merge _artifacts/*
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
@@ -202,8 +252,14 @@ jobs:
           name: tutorial-page
           path: _out/tutorial
 
+      - name: Fetch test tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: test-tarball
+          path: _tarball
+
       - name: Generate website
-        run: ./lka.py build-site
+        run: ./lka.py build-site --tarball _tarball/lean-arena-tests.tar.gz
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Upload artifact

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,68 +1,70 @@
 name: Build and Deploy Site
 
 on:
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch: # Manual trigger, also deploys the site
   pull_request: # Run on pull requests
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  create-runner:
-    name: Create Hetzner Cloud runner
+  select-checkers:
+    name: Select checkers
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'  # Only create runner for manual dispatch
     outputs:
-      label: ${{ steps.create-hcloud-runner.outputs.label }}
-      server_id: ${{ steps.create-hcloud-runner.outputs.server_id }}
+      checkers: ${{ steps.select.outputs.checkers }}
     steps:
-      - name: Create runner
-        id: create-hcloud-runner
-        uses: Cyclenerd/hcloud-github-runner@v1.3.0
-        with:
-          mode: create
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
-          server_type: ccx23
-          location: nbg1  # Nuremberg, Germany
-          image: ubuntu-24.04
-          ssh_key: ${{ secrets.HCLOUD_SSH_KEY_ID }}
-
-  build-and-deploy:
-    needs: create-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.create-runner.outputs.label || 'ubuntu-latest' }} # run on custom runner if available, otherwise default
-    if: always() # Run even if create-runner was skipped
-    timeout-minutes: 1440
-    
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    
-    steps:
-      # Workaround for: https://github.com/actions/runner/issues/1864
-      - name: Ensure HOME is defined
-        run: |
-          set -exuo pipefail
-          if [ -z "${HOME:-}" ]; then
-            HOME="$(getent passwd "$(id -u)" | cut -d: -f6)"
-            export HOME
-          fi
-          echo "HOME=$HOME" >> "$GITHUB_ENV"
-
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history, to compute the merge base of a pull request
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9
+
+      - name: Select checkers to run
+        id: select
+        run: .github/checker-matrix.sh >> "$GITHUB_OUTPUT"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+  check:
+    name: 'Checker: ${{ matrix.checker }}'
+    needs: select-checkers
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        checker: ${{ fromJSON(needs.select-checkers.outputs.checkers) }}
+    env:
+      CHECKER: ${{ matrix.checker }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Pages
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/configure-pages@v4
-
       - name: Setup nix shell
         run: "true"
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
+
       - name: Check perf support
         run: |
           echo "=== System info ==="
@@ -85,19 +87,75 @@ jobs:
           perf stat -e cycles -a -- true 2>&1 || echo "perf stat failed or not permitted"
         shell: 'nix develop -c bash -euxo pipefail {0}'
         continue-on-error: true
-      
-      - name: Build checkers
-        run: ./lka.py build-checker
+
+      - name: Build checker
+        run: ./lka.py build-checker "$CHECKER"
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Generate tests
-        run: ./lka.py build-test ${{ github.event_name != 'workflow_dispatch' && '--skip-ci' || '' }}
+        run: ./lka.py build-test --skip-declined-by "$CHECKER" ${{ github.event_name != 'workflow_dispatch' && '--skip-ci' || '' }}
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
-      - name: Run checkers on tests
-        run: ./lka.py run
+
+      - name: Run checker on tests
+        run: ./lka.py run --checker "$CHECKER"
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
+
+      - name: Stage results for upload
+        run: ./lka.py ci-pack --outdir /tmp/artifact
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: results-${{ matrix.checker }}
+          path: /tmp/artifact
+
+  build-site:
+    name: Build and deploy site
+    needs: check
+    if: ${{ !cancelled() && needs.check.result != 'skipped' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Pages
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/configure-pages@v4
+
+      - name: Setup nix shell
+        run: "true"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Fetch checker results
+        uses: actions/download-artifact@v8
+        with:
+          pattern: results-*
+          path: _artifacts
+
+      - name: Merge checker results
+        run: ./lka.py ci-merge _artifacts/*
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Build tutorial tests
+        run: ./lka.py build-test tutorial
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
       - name: Build tutorial test viewer
         run: |
           cd test-printer
@@ -108,7 +166,7 @@ jobs:
       - name: Generate website
         run: ./lka.py build-site
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -129,21 +187,3 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         id: deployment
         uses: actions/deploy-pages@v4
-
-
-  delete-runner:
-    name: Delete Hetzner Cloud runner
-    needs:
-      - create-runner
-      - build-and-deploy
-    runs-on: ubuntu-latest
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.create-runner.result != 'skipped' }} # Only delete if runner was created
-    steps:
-      - name: Delete runner
-        uses: Cyclenerd/hcloud-github-runner@v1
-        with:
-          mode: delete
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
-          name: ${{ needs.create-runner.outputs.label }}
-          server_id: ${{ needs.create-runner.outputs.server_id }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       checkers: ${{ steps.select.outputs.checkers }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # On pull requests, check out the PR head instead of the artificial
           # merge commit (empty ref means default behavior otherwise)
@@ -57,7 +57,7 @@ jobs:
       CHECKER: ${{ matrix.checker }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # On pull requests, check out the PR head instead of the artificial
           # merge commit (empty ref means default behavior otherwise)
@@ -117,9 +117,46 @@ jobs:
           name: results-${{ matrix.checker }}
           path: /tmp/artifact
 
+  tutorial:
+    name: Build tutorial page
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup nix shell
+        run: "true"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Build tutorial tests
+        run: ./lka.py build-test tutorial
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Build tutorial test viewer
+        run: |
+          cd test-printer
+          lake build
+          lake exe test-printer ../_build/tests/tutorial/ ../_out/tutorial/index.html
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Upload tutorial page
+        uses: actions/upload-artifact@v7
+        with:
+          name: tutorial-page
+          path: _out/tutorial
+
   build-site:
     name: Build and deploy site
-    needs: check
+    needs: [check, tutorial]
     if: ${{ !cancelled() && needs.check.result != 'skipped' }}
     runs-on: ubuntu-latest
 
@@ -130,7 +167,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # On pull requests, check out the PR head instead of the artificial
           # merge commit (empty ref means default behavior otherwise)
@@ -143,7 +180,7 @@ jobs:
 
       - name: Setup Pages
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Setup nix shell
         run: "true"
@@ -159,23 +196,18 @@ jobs:
         run: ./lka.py ci-merge _artifacts/*
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
-      - name: Build tutorial tests
-        run: ./lka.py build-test tutorial
-        shell: 'nix develop -c bash -euxo pipefail {0}'
-
-      - name: Build tutorial test viewer
-        run: |
-          cd test-printer
-          lake build
-          lake exe test-printer ../_build/tests/tutorial/ ../_out/tutorial/index.html
-        shell: 'nix develop -c bash -euxo pipefail {0}'
+      - name: Fetch tutorial page
+        uses: actions/download-artifact@v8
+        with:
+          name: tutorial-page
+          path: _out/tutorial
 
       - name: Generate website
         run: ./lka.py build-site
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '_out'
 
@@ -193,4 +225,4 @@ jobs:
       - name: Deploy to GitHub Pages
         if: github.event_name == 'workflow_dispatch'
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The following resources may be useful:
 * The thesis [The Type Theory of Lean](https://github.com/digama0/lean-type-theory/releases) by Mario Carneiro is a thorough description of Lean's theory.
 * The book [Type Checking in Lean4](https://ammkrn.github.io/type_checking_in_lean4/) by Chris Bailey has good advice on on writing a Lean kernel.
 * On the [arena website](https://arena.lean-lang.org/) you can download a zipfile with the arena tests (excluding large ones).
+* The arena website also publishes a machine-readable `results.json` with all checker metadata, test metadata and individual results, useful for further analysis.
 * The [source of the tutorial tests](https://github.com/leanprover/lean-kernel-arena/blob/master/tutorial/Tutorial.lean) suggests a sequence in which to implement tests.
 
 To add a new checker implementation:

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
           libffi
           libffi.dev
           pkg-config
+          jq
           just
           pypy
           monolith

--- a/lka.py
+++ b/lka.py
@@ -52,7 +52,7 @@ _configure_stdout_stderr_unbuffered()
 VERBOSE = False
 
 # Tests with .ndjson files larger than this are excluded from the downloadable
-# test tarball and from the CI artifacts (see ci-pack).
+# test tarball.
 TEST_SIZE_LIMIT = 10 * 1024 * 1024
 
 # Timing/measurement utilities
@@ -1735,6 +1735,39 @@ def create_test_tarball(tests: list, output_dir: Path) -> dict:
     }
 
 
+def tarball_info_from_file(tarball_path: Path) -> dict:
+    """Derive tarball statistics (as returned by create_test_tarball) from an
+    existing tarball file."""
+    import tarfile
+
+    good_count = 0
+    bad_count = 0
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        for member in tar:
+            if member.name.startswith("good/"):
+                good_count += 1
+            elif member.name.startswith("bad/"):
+                bad_count += 1
+
+    return {
+        "tarball_size": tarball_path.stat().st_size,
+        "good_count": good_count,
+        "bad_count": bad_count
+    }
+
+
+def cmd_build_tarball(args: argparse.Namespace) -> int:
+    """Handle the build-tarball command."""
+    output_dir = Path(args.outdir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tests = load_tests()
+    tarball_info = create_test_tarball(tests, output_dir)
+    print(f"Created {output_dir / 'lean-arena-tests.tar.gz'} "
+          f"({tarball_info['good_count']} good tests, {tarball_info['bad_count']} bad tests, "
+          f"{format_memory(tarball_info['tarball_size'])})")
+    return 0
+
+
 def collect_results_data() -> dict:
     """Collect checkers, tests, results and build metadata into a single
     JSON-serializable structure.
@@ -1865,8 +1898,15 @@ def cmd_build_site(args: argparse.Namespace) -> int:
 
     checkers.sort(key=sort_key)
 
-    # Create test tarball
-    tarball_info = create_test_tarball(tests, output_dir)
+    # Create the test tarball, or take a pre-built one (see build-tarball)
+    tarball_file = output_dir / "lean-arena-tests.tar.gz"
+    if args.tarball:
+        tarball_src = Path(args.tarball)
+        if tarball_src.resolve() != tarball_file.resolve():
+            shutil.copy2(tarball_src, tarball_file)
+        tarball_info = tarball_info_from_file(tarball_file)
+    else:
+        tarball_info = create_test_tarball(tests, output_dir)
 
     # Build context data
     data = {
@@ -2040,27 +2080,27 @@ def cmd_list_checkers(args: argparse.Namespace) -> int:
 def cmd_ci_pack(args: argparse.Namespace) -> int:
     """Handle the ci-pack command.
 
-    Stages, preserving project-relative paths:
-    - all result files from _results/
-    - all test .stats.json files from _build/tests/
-    - test .ndjson files up to the size limit (so that the aggregating CI job
-      can offer the test tarball for download)
+    Stages the selected data, preserving project-relative paths:
+    - --results: all result files from _results/
+    - --test-stats: all test .stats.json files from _build/tests/
     """
+    if not (args.results or args.test_stats):
+        print("Error: nothing to stage; pass --results and/or --test-stats")
+        return 1
+
     root = get_project_root()
     outdir = Path(args.outdir)
 
     files = []
-    results_dir = root / "_results"
-    if results_dir.exists():
-        files.extend(sorted(results_dir.glob("*.json")))
+    if args.results:
+        results_dir = root / "_results"
+        if results_dir.exists():
+            files.extend(sorted(results_dir.glob("*.json")))
 
-    tests_dir = root / "_build" / "tests"
-    if tests_dir.exists():
-        for stats_file in sorted(tests_dir.rglob("*.stats.json")):
-            files.append(stats_file)
-            ndjson_file = stats_file.parent / (stats_file.stem.replace('.stats', '') + '.ndjson')
-            if ndjson_file.exists() and ndjson_file.stat().st_size <= TEST_SIZE_LIMIT:
-                files.append(ndjson_file)
+    if args.test_stats:
+        tests_dir = root / "_build" / "tests"
+        if tests_dir.exists():
+            files.extend(sorted(tests_dir.rglob("*.stats.json")))
 
     for file in files:
         dest = outdir / file.relative_to(root)
@@ -2195,6 +2235,22 @@ def main() -> int:
         metavar="FILE",
         help="Render the site from a previously written results.json instead of collecting the data (see write-results)",
     )
+    build_site_parser.add_argument(
+        "--tarball",
+        metavar="FILE",
+        help="Use a pre-built test tarball instead of creating one (see build-tarball)",
+    )
+
+    # build-tarball command
+    build_tarball_parser = subparsers.add_parser(
+        "build-tarball",
+        help="Create the downloadable test tarball from the built tests",
+    )
+    build_tarball_parser.add_argument(
+        "--outdir",
+        default="_out",
+        help="Output directory for the tarball (default: _out)",
+    )
 
     # write-results command
     write_results_parser = subparsers.add_parser(
@@ -2228,6 +2284,16 @@ def main() -> int:
         required=True,
         help="Directory to stage the files in",
     )
+    ci_pack_parser.add_argument(
+        "--results",
+        action="store_true",
+        help="Stage the result files from _results/",
+    )
+    ci_pack_parser.add_argument(
+        "--test-stats",
+        action="store_true",
+        help="Stage the test .stats.json files from _build/tests/",
+    )
 
     # ci-merge command
     ci_merge_parser = subparsers.add_parser(
@@ -2259,6 +2325,8 @@ def main() -> int:
         return cmd_build_site(args)
     elif args.command == "write-results":
         return cmd_write_results(args)
+    elif args.command == "build-tarball":
+        return cmd_build_tarball(args)
     elif args.command == "list-checkers":
         return cmd_list_checkers(args)
     elif args.command == "ci-pack":

--- a/lka.py
+++ b/lka.py
@@ -11,6 +11,7 @@
 
 import argparse
 import datetime
+import filecmp
 import fnmatch
 import json
 import os
@@ -49,6 +50,10 @@ _configure_stdout_stderr_unbuffered()
 
 # Global verbose flag
 VERBOSE = False
+
+# Tests with .ndjson files larger than this are excluded from the downloadable
+# test tarball and from the CI artifacts (see ci-pack).
+TEST_SIZE_LIMIT = 10 * 1024 * 1024
 
 # Timing/measurement utilities
 
@@ -1070,6 +1075,18 @@ def cmd_build_test(args: argparse.Namespace) -> int:
         if skipped_count > 0:
             print(f"Skipping {skipped_count} test(s) due to --skip-ci flag")
 
+    # Filter out tests that the given checker declaratively declines
+    if args.skip_declined_by:
+        checker = find_checker_by_name(args.skip_declined_by)
+        if checker is None:
+            print(f"No checker found: {args.skip_declined_by}")
+            return 1
+        declines = set(checker.get("declines", []))
+        skipped = [test["name"] for test in tests if test["name"] in declines]
+        if skipped:
+            tests = [test for test in tests if test["name"] not in declines]
+            print(f"Skipping {len(skipped)} test(s) declined by {checker['name']}: {', '.join(skipped)}")
+
     if not tests:
         print("No tests found.")
         return 0
@@ -1167,6 +1184,29 @@ def cmd_build_checker(args: argparse.Namespace) -> int:
 # =============================================================================
 
 
+def write_declined_result(checker_name: str, test_name: str, results_dir: Path) -> dict:
+    """Record a declaratively declined (checker, test) pair without running the checker."""
+    result_data = {
+        "checker": checker_name,
+        "test": test_name,
+        "status": "declined",
+        "correctness": "declined",
+        "exit_code": 2,
+        "wall_time": 0,
+        "cpu_time": 0,
+        "max_rss": 0,
+        "instructions": 0,
+        "stdout": "",
+        "stderr": "Declined via the `declines` field in the checker configuration; the checker was not run.",
+    }
+    results_dir.mkdir(parents=True, exist_ok=True)
+    safe_test_name = test_name.replace("/", "_")
+    result_file = results_dir / f"{checker_name}_{safe_test_name}.json"
+    with open(result_file, "w") as f:
+        json.dump(result_data, f, indent=2)
+    return result_data
+
+
 def run_checker_on_test(checker: dict, test: dict, build_dir: Path, tests_dir: Path, results_dir: Path) -> dict:
     """Run a checker on a test and return the result."""
     checker_name = checker["name"]
@@ -1175,30 +1215,12 @@ def run_checker_on_test(checker: dict, test: dict, build_dir: Path, tests_dir: P
 
     # Tests listed in the checker's `declines` are declined without running
     if test_name in checker.get("declines", []):
-        result_data = {
-            "checker": checker_name,
-            "test": test_name,
-            "status": "declined",
-            "correctness": "declined",
-            "exit_code": 2,
-            "wall_time": 0,
-            "cpu_time": 0,
-            "max_rss": 0,
-            "instructions": 0,
-            "stdout": "",
-            "stderr": "Declined via the `declines` field in the checker configuration; the checker was not run.",
-        }
-        results_dir.mkdir(parents=True, exist_ok=True)
-        safe_test_name = test_name.replace("/", "_")
-        result_file = results_dir / f"{checker_name}_{safe_test_name}.json"
-        with open(result_file, "w") as f:
-            json.dump(result_data, f, indent=2)
-        return result_data
+        return write_declined_result(checker_name, test_name, results_dir)
 
     # Use the file path stored in the test dict
-    test_file = test["file"]
+    test_file = test.get("file")
 
-    if not test_file.exists():
+    if test_file is None or not test_file.exists():
         result_data = {
             "checker": checker_name,
             "test": test_name,
@@ -1366,6 +1388,18 @@ def cmd_run_checker(args: argparse.Namespace) -> int:
             
             print(f"[{status_emoji} {correctness_emoji} {format_duration(result['wall_time'])}]")
 
+        # Also record declaratively declined tests that are not among the
+        # built tests (e.g. because `build-test --skip-declined-by` skipped
+        # building them).
+        built_test_names = {test["name"] for test in tests}
+        for declined_name in checker.get("declines", []):
+            if declined_name in built_test_names:
+                continue
+            if args.test and not fnmatch.fnmatch(declined_name, args.test):
+                continue
+            print(f"Declining {declined_name} for {checker['name']} (declared in checker configuration) [⊘]")
+            results.append(write_declined_result(checker["name"], declined_name, results_dir))
+
     # Summary
     print("\n" + "=" * 60)
     print("Summary:")
@@ -1438,14 +1472,13 @@ def load_tests() -> list[dict]:
             with open(stats_file, "r") as f:
                 test_data = json.load(f)
 
-            # Determine the corresponding .ndjson file path based on stats file location
+            # Determine the corresponding .ndjson file path based on stats file location.
+            # The .ndjson file may be absent, e.g. when only the stats files were
+            # fetched from a CI artifact; such tests can still be shown on the
+            # website, but not be run or included in the tarball.
             ndjson_file = stats_file.parent / (stats_file.stem.replace('.stats', '') + '.ndjson')
-            if ndjson_file.exists():
-                # Add the file path that callers expect
-                test_data["file"] = ndjson_file
-                tests.append(test_data)
-            else:
-                print(f"Warning: No corresponding .ndjson file for {stats_file}")
+            test_data["file"] = ndjson_file if ndjson_file.exists() else None
+            tests.append(test_data)
 
         except Exception as e:
             print(f"Warning: Could not read stats file {stats_file}: {e}")
@@ -1666,13 +1699,14 @@ def create_test_tarball(tests: list, output_dir: Path) -> dict:
 
     with tarfile.open(tarball_path, "w:gz") as tar:
         for test in tests:
-            # Skip tests larger than 10 MB
-            if test.get("size", 0) > 10*1024*1024:
+            # Skip tests larger than the size limit
+            if test.get("size", 0) > TEST_SIZE_LIMIT:
                 continue
 
-            # Use the file path from test data
-            test_file = test["file"]
-            if not test_file.exists():
+            # Use the file path from test data (may be absent for tests whose
+            # stats came from a CI artifact without the .ndjson file)
+            test_file = test.get("file")
+            if test_file is None or not test_file.exists():
                 continue
 
             outcome = test.get("outcome", "unknown")
@@ -1701,6 +1735,43 @@ def create_test_tarball(tests: list, output_dir: Path) -> dict:
     }
 
 
+def collect_results_data() -> dict:
+    """Collect checkers, tests, results and build metadata into a single
+    JSON-serializable structure.
+
+    This is the content of the published results.json file, and also the data
+    the website is rendered from, so it is a complete description of the
+    site's data.
+    """
+    checkers = load_checkers()
+    tests = load_tests()
+    results = load_results()
+    return {
+        "meta": get_build_metadata(),
+        "checkers": [
+            {k: v for k, v in checker.items() if k != "_file"}
+            for checker in checkers
+        ],
+        "tests": [
+            # The local .ndjson path is not meaningful outside this checkout
+            {k: v for k, v in test.items() if k != "file"}
+            for test in tests
+        ],
+        "results": [results[key] for key in sorted(results)],
+    }
+
+
+def cmd_write_results(args: argparse.Namespace) -> int:
+    """Handle the write-results command."""
+    out_file = Path(args.out)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    data = collect_results_data()
+    with open(out_file, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"Wrote {out_file} ({len(data['checkers'])} checkers, {len(data['tests'])} tests, {len(data['results'])} results)")
+    return 0
+
+
 def cmd_build_site(args: argparse.Namespace) -> int:
     """Handle the build-site command."""
     output_dir = Path(args.outdir)
@@ -1716,9 +1787,31 @@ def cmd_build_site(args: argparse.Namespace) -> int:
         autoescape=select_autoescape(),
     )
 
-    checkers = load_checkers()
-    results = load_results()
-    tests = load_tests()
+    # The site is rendered from the results.json data structure, either read
+    # from a previously written file (--results) or collected now.
+    if args.results:
+        with open(args.results, "r") as f:
+            results_data = json.load(f)
+    else:
+        results_data = collect_results_data()
+
+    # Publish the raw data alongside the site
+    results_json_file = output_dir / "results.json"
+    with open(results_json_file, "w") as f:
+        json.dump(results_data, f, indent=2)
+    results_json_info = {"size": results_json_file.stat().st_size}
+    print(f"Generated: {results_json_file}")
+
+    checkers = results_data["checkers"]
+    tests = results_data["tests"]
+    results = {(r["checker"], r["test"]): r for r in results_data["results"]}
+    build_info = results_data.get("meta", {})
+
+    # Attach local .ndjson file paths where available (needed for the test
+    # tarball; deliberately not part of results.json)
+    test_files = {test["name"]: test.get("file") for test in load_tests()}
+    for test in tests:
+        test["file"] = test_files.get(test["name"])
 
     # Calculate global instructions per second from results with both cpu_time and instructions
     total_instructions = 0
@@ -1772,9 +1865,6 @@ def cmd_build_site(args: argparse.Namespace) -> int:
 
     checkers.sort(key=sort_key)
 
-    # Get build metadata
-    build_info = get_build_metadata()
-
     # Create test tarball
     tarball_info = create_test_tarball(tests, output_dir)
 
@@ -1791,6 +1881,7 @@ def cmd_build_site(args: argparse.Namespace) -> int:
         "instructions_per_second": instructions_per_second,
         "build_info": build_info,
         "tarball_info": tarball_info,
+        "results_json_info": results_json_info,
     }
 
     # Render index.html
@@ -1931,6 +2022,99 @@ def cmd_build_site(args: argparse.Namespace) -> int:
 
 
 # =============================================================================
+# CI support commands
+# =============================================================================
+
+
+def cmd_list_checkers(args: argparse.Namespace) -> int:
+    """Handle the list-checkers command."""
+    names = [checker["name"] for checker in load_checkers()]
+    if args.json:
+        print(json.dumps(names))
+    else:
+        for name in names:
+            print(name)
+    return 0
+
+
+def cmd_ci_pack(args: argparse.Namespace) -> int:
+    """Handle the ci-pack command.
+
+    Stages, preserving project-relative paths:
+    - all result files from _results/
+    - all test .stats.json files from _build/tests/
+    - test .ndjson files up to the size limit (so that the aggregating CI job
+      can offer the test tarball for download)
+    """
+    root = get_project_root()
+    outdir = Path(args.outdir)
+
+    files = []
+    results_dir = root / "_results"
+    if results_dir.exists():
+        files.extend(sorted(results_dir.glob("*.json")))
+
+    tests_dir = root / "_build" / "tests"
+    if tests_dir.exists():
+        for stats_file in sorted(tests_dir.rglob("*.stats.json")):
+            files.append(stats_file)
+            ndjson_file = stats_file.parent / (stats_file.stem.replace('.stats', '') + '.ndjson')
+            if ndjson_file.exists() and ndjson_file.stat().st_size <= TEST_SIZE_LIMIT:
+                files.append(ndjson_file)
+
+    for file in files:
+        dest = outdir / file.relative_to(root)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(file, dest)
+
+    print(f"Staged {len(files)} file(s) in {outdir}")
+    return 0
+
+
+def cmd_ci_merge(args: argparse.Namespace) -> int:
+    """Handle the ci-merge command.
+
+    Merges directories staged by ci-pack back into the project, copying each
+    file to its project-relative location. A file that already exists (from a
+    previous artifact or a local build) must be byte-identical; anything else
+    indicates that the CI jobs did not build the same test data, and the merge
+    fails.
+    """
+    root = get_project_root()
+    copied = 0
+    identical = 0
+    conflicts = []
+
+    for dir_str in args.dirs:
+        artifact_dir = Path(dir_str)
+        if not artifact_dir.is_dir():
+            print(f"Error: Not a directory: {artifact_dir}")
+            return 1
+        for file in sorted(path for path in artifact_dir.rglob("*") if path.is_file()):
+            rel = file.relative_to(artifact_dir)
+            dest = root / rel
+            if dest.exists():
+                if filecmp.cmp(file, dest, shallow=False):
+                    identical += 1
+                else:
+                    conflicts.append((rel, artifact_dir))
+            else:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(file, dest)
+                copied += 1
+
+    print(f"Merged {len(args.dirs)} artifact(s): {copied} file(s) copied, {identical} identical duplicate(s)")
+
+    if conflicts:
+        print("Error: The following files differ from an already present copy, but should be identical:")
+        for rel, artifact_dir in conflicts:
+            print(f"  {rel} (from {artifact_dir})")
+        return 1
+
+    return 0
+
+
+# =============================================================================
 # Main entry point
 # =============================================================================
 
@@ -1964,6 +2148,11 @@ def main() -> int:
         "--skip-ci",
         action="store_true",
         help="Skip tests marked with 'skip-on-ci: true' in YAML",
+    )
+    build_test_parser.add_argument(
+        "--skip-declined-by",
+        metavar="CHECKER",
+        help="Skip tests listed in the given checker's 'declines' field",
     )
 
     # build-checker command
@@ -2001,6 +2190,55 @@ def main() -> int:
         default="_out",
         help="Output directory for the website (default: _out)",
     )
+    build_site_parser.add_argument(
+        "--results",
+        metavar="FILE",
+        help="Render the site from a previously written results.json instead of collecting the data (see write-results)",
+    )
+
+    # write-results command
+    write_results_parser = subparsers.add_parser(
+        "write-results",
+        help="Write all checker/test metadata and results into a single results.json file",
+    )
+    write_results_parser.add_argument(
+        "--out",
+        default="_build/results.json",
+        help="Output file (default: _build/results.json)",
+    )
+
+    # list-checkers command
+    list_checkers_parser = subparsers.add_parser(
+        "list-checkers",
+        help="List all enabled checkers",
+    )
+    list_checkers_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as a JSON array",
+    )
+
+    # ci-pack command
+    ci_pack_parser = subparsers.add_parser(
+        "ci-pack",
+        help="Stage results and test metadata for upload as a CI artifact",
+    )
+    ci_pack_parser.add_argument(
+        "--outdir",
+        required=True,
+        help="Directory to stage the files in",
+    )
+
+    # ci-merge command
+    ci_merge_parser = subparsers.add_parser(
+        "ci-merge",
+        help="Merge CI artifact directories (created by ci-pack) back into the project, checking that duplicate files are identical",
+    )
+    ci_merge_parser.add_argument(
+        "dirs",
+        nargs="+",
+        help="Artifact directories to merge",
+    )
 
     args = parser.parse_args()
 
@@ -2019,6 +2257,14 @@ def main() -> int:
         return cmd_run_checker(args)
     elif args.command == "build-site":
         return cmd_build_site(args)
+    elif args.command == "write-results":
+        return cmd_write_results(args)
+    elif args.command == "list-checkers":
+        return cmd_list_checkers(args)
+    elif args.command == "ci-pack":
+        return cmd_ci_pack(args)
+    elif args.command == "ci-merge":
+        return cmd_ci_merge(args)
     else:
         parser.print_help()
         return 1

--- a/templates/index.html
+++ b/templates/index.html
@@ -231,6 +231,10 @@ table thead th {
     </p>
 
     <p>
+        The raw data behind this page is available as <a href="results.json"><tt>results.json</tt></a> ({{ format_memory(results_json_info.size) }}). It contains the checker metadata (<tt>checkers</tt>), the test metadata (<tt>tests</tt>) and the array of all individual results (<tt>results</tt>), and may be useful for further analysis of the data.
+    </p>
+
+    <p>
         The test suite includes a set of <a href="tutorial/">tutorial test cases</a> that exercise individual features of the Lean type system step by step, from basic definitions through inductives, recursors, projections, definitional equality rules, and quotient types.
         Each tutorial test is a small self-contained environment, making them a useful starting point for developing and debugging a new kernel checker.
     </p>


### PR DESCRIPTION
Replace the single Hetzner Cloud runner with parallel jobs on normal GitHub runners, as suggested by Jeremy Chen.

## Workflow structure

* **select-checkers**: determines the checker matrix via the new `lka.py list-checkers`. If a PR touches nothing but `checkers/*.yaml` (diffed between the PR head and its merge base), only the touched checkers are selected.
* **Checker: \***  (matrix, one job per checker): builds the checker, builds the tests it does not declaratively decline (`build-test --skip-declined-by`, plus `--skip-ci` on PRs), runs it, and uploads only its results as an artifact (`ci-pack --results`).
* **test-stats**: builds all tests (`--skip-ci` applies) and is the sole source for the test `.stats.json` files (`ci-pack --test-stats`) and the downloadable test tarball (new `build-tarball` command).
* **tutorial**: builds the tutorial tests and renders the tutorial page, in parallel with everything else.
* **build-site**: merges all artifacts with the new `ci-merge`, which fails if duplicated files are not byte-identical; builds the site (taking the pre-built tarball via `build-site --tarball`); deploys on `workflow_dispatch` as before.

The workflow only interacts with `lka.py`-owned data through new subcommands; the `.github/` scripts do not peek into `_results`/`_build` themselves.

## results.json

The site is now rendered from a single data structure containing the checker metadata, test metadata, all individual results, and build metadata (date, revision, CI run). It is published as `results.json` alongside the site and linked from the summary page, for external analysis. A new `write-results` command dumps it, and `build-site --results` renders a site from a previously written file.

Further notable changes:

* Declaratively declined tests are recorded as declined even when they were never built.
* Tests whose `.ndjson` is absent locally (they are no longer shipped in artifacts) still appear on the site from their stats.
* All checkouts pin the PR head commit instead of GitHub's artificial merge commit.
* `actions/checkout` and the Pages actions were bumped to current major versions (Node.js 20 deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6eedjfpntSKyEKsNPBxb3