### PR TITLE
Collapse test groups (perf/, tutorial/) in the result tables

### DIFF
--- a/lka.py
+++ b/lka.py
@@ -1768,6 +1768,59 @@ def cmd_build_tarball(args: argparse.Namespace) -> int:
     return 0
 
 
+def result_virtual_time(result: dict, instructions_per_second: float) -> float:
+    """Virtual CPU time of a result: derived from the instruction count if
+    available, falling back to the measured CPU time."""
+    instructions = result.get("instructions") or 0
+    if instructions > 0 and instructions_per_second > 0:
+        return instructions / instructions_per_second
+    return result.get("cpu_time") or 0
+
+
+def group_rows(members: list, name_of) -> list[dict]:
+    """Group a list of table rows by test group for collapsible display.
+
+    Members whose test name has a directory component (e.g. "perf/app-lam")
+    are grouped by its first component. Returns a list of row dicts: first
+    {"is_group": False, "member": m} for the ungrouped members, then, at the
+    end of the table, {"is_group": True, "name": g, "members": [...]} for
+    each group.
+    """
+    rows = []
+    trailing_rows = []
+    groups = {}
+    for member in members:
+        name = name_of(member)
+        if "/" not in name:
+            rows.append({"is_group": False, "member": member})
+            continue
+        group_name = name.split("/", 1)[0]
+        if group_name not in groups:
+            groups[group_name] = {"is_group": True, "name": group_name, "members": []}
+            trailing_rows.append(groups[group_name])
+        groups[group_name]["members"].append(member)
+    return rows + trailing_rows
+
+
+def summarize_correctness(result_list: list[dict]) -> dict:
+    """Tally the correctness of a list of results (for group summary rows).
+
+    Errors are counted as declined, matching the scoring elsewhere.
+    """
+    counts = {"present": 0, "correct": 0, "incorrect": 0, "declined": 0, "either": 0}
+    for result in result_list:
+        if result is None:
+            continue
+        counts["present"] += 1
+        correctness = result.get("correctness", "error")
+        if correctness == "error":
+            correctness = "declined"
+        counts[correctness] = counts.get(correctness, 0) + 1
+    # Scored tests: those that count towards completeness/soundness plus declines
+    counts["scored"] = counts["correct"] + counts["incorrect"] + counts["declined"]
+    return counts
+
+
 def collect_results_data() -> dict:
     """Collect checkers, tests, results and build metadata into a single
     JSON-serializable structure.
@@ -1898,6 +1951,22 @@ def cmd_build_site(args: argparse.Namespace) -> int:
 
     checkers.sort(key=sort_key)
 
+    # Group tests (e.g. perf/, tutorial/) into collapsible table rows, with
+    # per-checker summary statistics for the group summary row
+    test_rows = group_rows(tests, lambda test: test["name"])
+    for row in test_rows:
+        if not row["is_group"]:
+            continue
+        row["count"] = len(row["members"])
+        row["size"] = sum(test.get("size", 0) for test in row["members"])
+        row["size_str"] = format_memory(row["size"])
+        row["checker_stats"] = {
+            checker["name"]: summarize_correctness(
+                [results.get((checker["name"], test["name"])) for test in row["members"]]
+            )
+            for checker in checkers
+        }
+
     # Create the test tarball, or take a pre-built one (see build-tarball)
     tarball_file = output_dir / "lean-arena-tests.tar.gz"
     if args.tarball:
@@ -1911,6 +1980,7 @@ def cmd_build_site(args: argparse.Namespace) -> int:
     # Build context data
     data = {
         "tests": tests,
+        "test_rows": test_rows,
         "checkers": checkers,
         "test_results": results,  # Pass results dict with (checker, test) keys
         "format_duration": format_duration,
@@ -1972,6 +2042,30 @@ def cmd_build_site(args: argparse.Namespace) -> int:
             # Sort checker results by name (alphabetical order)
             checker_results.sort(key=lambda result: result.get("test", ""))
 
+            # Group tests (e.g. perf/, tutorial/) into collapsible table rows
+            result_rows = group_rows(checker_results, lambda result: result["test"])
+            for row in result_rows:
+                if not row["is_group"]:
+                    continue
+                row["count"] = len(row["members"])
+                row.update(summarize_correctness(row["members"]))
+                row["time_sum"] = sum(result_virtual_time(r, instructions_per_second) for r in row["members"])
+                row["rss_max"] = max(r.get("max_rss") or 0 for r in row["members"])
+                # Overall performance relative to the official checker, summed
+                # over the tests that both checkers accepted
+                own_time = 0.0
+                official_time = 0.0
+                for r in row["members"]:
+                    official = r.get("official")
+                    if (r.get("expected") == "accept" and r.get("status") == "accepted"
+                            and official and official.get("status") == "accepted"):
+                        own_time += result_virtual_time(r, instructions_per_second)
+                        official_time += result_virtual_time(official, instructions_per_second)
+                if official_time >= 0.05 and own_time > 0:
+                    row["percent"] = round((own_time - official_time) / official_time * 100)
+                else:
+                    row["percent"] = None
+
             # Create a copy of checker data with rendered description
             checker_with_rendered_desc = checker.copy()
             checker_with_rendered_desc["description"] = render_markdown(checker.get("description", ""))
@@ -1980,6 +2074,7 @@ def cmd_build_site(args: argparse.Namespace) -> int:
                 "checker": checker_with_rendered_desc,
                 "checker_links": checker_links,
                 "results": checker_results,
+                "result_rows": result_rows,
                 "format_duration": format_duration,
                 "format_memory": format_memory,
                 "format_instructions": format_instructions,

--- a/templates/checker.html
+++ b/templates/checker.html
@@ -1,6 +1,19 @@
 {% extends "base.html" %}
 {% from "macros.html" import detail_styles, result_status_cell, perf_cells, perf_header %}
 
+{# One result row in the results table; group members are shown indented, without the group prefix #}
+{% macro result_row(result, group) %}
+            <tr>
+                <td{% if group %} class="group-member"{% endif %}><a href="#test-{{ result.test }}">{% if group %}{{ result.test[(group | length) + 1:] }}{% else %}{{ result.test }}{% endif %}</a></td>
+                <td class="spacer-col"></td>
+                <td class="text-center">
+                    {% if result.expected == 'accept' %}👍{% elif result.expected == 'reject' %}✋{% elif result.expected == 'either' %}🤷{% else %}⚠️ {{ result.expected }}{% endif %}
+                </td>
+                {{ result_status_cell(result.expected, result.status) }}
+                {{ perf_cells(result, result.expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time) }}
+            </tr>
+{% endmacro %}
+
 {% block static_path %}../../{% endblock %}
 
 {% block title %}{{ checker.name }} - Lean Kernel Arena{% endblock %}
@@ -102,18 +115,35 @@ section pre, details pre {
             </tr>
         </thead>
         <tbody>
-            {% for result in results %}
-            <tr>
-                <td><a href="#test-{{ result.test }}">{{ result.test }}</a></td>
-                <td class="spacer-col"></td>
-                <td class="text-center">
-                    {% if result.expected == 'accept' %}👍{% elif result.expected == 'reject' %}✋{% elif result.expected == 'either' %}🤷{% else %}⚠️ {{ result.expected }}{% endif %}
-                </td>
-                {{ result_status_cell(result.expected, result.status) }}
-                {{ perf_cells(result, result.expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time) }}
-            </tr>
+            {% for row in result_rows if not row.is_group %}
+            {{ result_row(row.member, none) }}
             {% endfor %}
         </tbody>
+        {% for row in result_rows if row.is_group %}
+        <tbody class="group">
+            <tr class="group-summary">
+                <td><label title="Click to show the individual tests"><input type="checkbox" class="group-toggle"><span class="group-arrow"></span>{{ row.name }}/ <span class="text-muted">({{ row.count }} tests)</span></label></td>
+                <td class="spacer-col"></td>
+                <td class="text-center"></td>
+                <td class="text-center {% if row.incorrect > 0 %}bg-error{% elif row.declined > 0 %}bg-warning{% endif %}">
+                    <span title="{{ row.correct }} correct, {{ row.incorrect }} incorrect, {{ row.declined }} declined or crashed{% if row.either %}, {{ row.either }} either{% endif %}">{{ row.correct }}</span>
+                </td>
+                <td class="text-right">
+                    {% if row.time_sum %}<span title="Total over all tests in the group">{{ format_duration(row.time_sum) }}</span>{% endif %}
+                </td>
+                <td class="text-left">
+                    {% if row.percent is not none %}({% if row.percent > 0 %}+{% endif %}{{ row.percent }}%){% endif %}
+                </td>
+                <td class="text-right">
+                    {% if row.rss_max %}<span title="Maximum over all tests in the group">{{ format_memory(row.rss_max) }}</span>{% endif %}
+                </td>
+                <td class="text-left"></td>
+            </tr>
+            {% for result in row.members %}
+            {{ result_row(result, row.name) }}
+            {% endfor %}
+        </tbody>
+        {% endfor %}
     </table>
     </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,86 @@
 
 {% block static_path %}{% endblock %}
 
+{# One test row in the Tests table; group members are shown indented, without the group prefix #}
+{% macro test_row(test, group) %}
+            <tr>
+                <td{% if group %} class="group-member"{% endif %}><a href="test/{{ test.name }}/">{% if group %}{{ test.name[(group | length) + 1:] }}{% else %}{{ test.name }}{% endif %}</a>{% if test.outcome == 'either' %} <span title="No expected outcome: accepting and rejecting are both acceptable">🤷</span>{% endif %}</td>
+                <td class="spacer-col"></td>
+                {% for checker in checkers %}
+                    {% if checker.name == 'official' %}
+                    {% set key = (checker.name, test.name) %}
+                    {% set result = test_results.get(key) %}
+                    <td class="text-center official-column {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
+                        {% if result %}
+                        <a href="checker/{{ checker.name }}/#test-{{ test.name }}" style="text-decoration: none; color: inherit; display: block;">
+                            {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
+                                {# Show absolute virtual time for perf-compared tests #}
+                                {% set official_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
+                                {% if official_cpu_time and official_cpu_time >= 0.05 %}
+                                    {{ format_duration(official_cpu_time) }}
+                                {% else %}
+                                    👍
+                                {% endif %}
+                            {% else %}
+                                {# Show result status for other tests #}
+                                {% if result.status == 'accepted' %}👍{% elif result.status == 'rejected' %}✋{% elif result.status == 'declined' %}🚫{% else %}💥{% endif %}
+                            {% endif %}
+                        </a>
+                        {% else %}
+                            -
+                        {% endif %}
+                    </td>
+                    {% endif %}
+                {% endfor %}
+                {% for checker in checkers %}
+                    {% if checker.name != 'official' %}
+                    {% set key = (checker.name, test.name) %}
+                    {% set result = test_results.get(key) %}
+                    <td class="text-center {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
+                        {% if result %}
+                        <a href="checker/{{ checker.name }}/#test-{{ test.name }}" style="text-decoration: none; color: inherit; display: block;">
+                            {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
+                                {# Show performance comparison for perf-compared tests #}
+                                {% set official_key = ('official', test.name) %}
+                                {% set official_result = test_results.get(official_key) %}
+                                {% if official_result and official_result.status == 'accepted' %}
+                                    {% set official_cpu_time = convert_instructions_to_time(official_result.get('instructions', 0), instructions_per_second) if official_result.get('instructions', 0) > 0 and instructions_per_second > 0 else official_result.cpu_time %}
+                                    {% set current_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
+                                    {% if official_cpu_time and official_cpu_time >= 0.05 and current_cpu_time %}
+                                        {% set percent_change = ((current_cpu_time - official_cpu_time) / official_cpu_time * 100) | round(0) | int %}
+                                        {% if percent_change > 0 %}+{{ percent_change }}%{% elif percent_change < 0 %}{{ percent_change }}%{% else %}0%{% endif %}
+                                    {% else %}
+                                        👍
+                                    {% endif %}
+                                {% else %}
+                                    👍
+                                {% endif %}
+                            {% else %}
+                                {# Show result status for other tests #}
+                                {% if result.status == 'accepted' %}👍{% elif result.status == 'rejected' %}✋{% elif result.status == 'declined' %}🚫{% else %}💥{% endif %}
+                            {% endif %}
+                        </a>
+                        {% else %}
+                            -
+                        {% endif %}
+                    </td>
+                    {% endif %}
+                {% endfor %}
+                <td class="text-right">{{ test.size_str }}</td>
+            </tr>
+{% endmacro %}
+
+{# Aggregated per-checker cell in a group summary row #}
+{% macro group_summary_cell(stats, official) %}
+                <td class="text-center {% if official %}official-column {% endif %}{% if stats.present == 0 %}{% elif stats.incorrect > 0 %}bg-error{% elif stats.declined > 0 %}bg-warning{% endif %}">
+                    {% if stats.present == 0 %}
+                        -
+                    {% else %}
+                        <span title="{{ stats.correct }} correct, {{ stats.incorrect }} incorrect, {{ stats.declined }} declined or crashed{% if stats.either %}, {{ stats.either }} either{% endif %}">{{ stats.correct }}</span>
+                    {% endif %}
+                </td>
+{% endmacro %}
+
 {% block style %}
 .checker-name { font-weight: 600; }
 .bg-success { background-color: #d4edda; }
@@ -123,74 +203,28 @@ table thead th {
             </tr>
         </thead>
         <tbody>
-            {% for test in tests %}
-            <tr>
-                <td><a href="test/{{ test.name }}/">{{ test.name }}</a></td>
-                <td class="spacer-col"></td>
-                {% for checker in checkers %}
-                    {% if checker.name == 'official' %}
-                    {% set key = (checker.name, test.name) %}
-                    {% set result = test_results.get(key) %}
-                    <td class="text-center official-column {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
-                        {% if result %}
-                        <a href="checker/{{ checker.name }}/#test-{{ test.name }}" style="text-decoration: none; color: inherit; display: block;">
-                            {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
-                                {# Show absolute virtual time for perf-compared tests #}
-                                {% set official_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
-                                {% if official_cpu_time and official_cpu_time >= 0.05 %}
-                                    {{ format_duration(official_cpu_time) }}
-                                {% else %}
-                                    👍
-                                {% endif %}
-                            {% else %}
-                                {# Show result status for other tests #}
-                                {% if result.status == 'accepted' %}👍{% elif result.status == 'rejected' %}✋{% elif result.status == 'declined' %}🚫{% else %}💥{% endif %}
-                            {% endif %}
-                        </a>
-                        {% else %}
-                            -
-                        {% endif %}
-                    </td>
-                    {% endif %}
-                {% endfor %}
-                {% for checker in checkers %}
-                    {% if checker.name != 'official' %}
-                    {% set key = (checker.name, test.name) %}
-                    {% set result = test_results.get(key) %}
-                    <td class="text-center {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
-                        {% if result %}
-                        <a href="checker/{{ checker.name }}/#test-{{ test.name }}" style="text-decoration: none; color: inherit; display: block;">
-                            {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
-                                {# Show performance comparison for perf-compared tests #}
-                                {% set official_key = ('official', test.name) %}
-                                {% set official_result = test_results.get(official_key) %}
-                                {% if official_result and official_result.status == 'accepted' %}
-                                    {% set official_cpu_time = convert_instructions_to_time(official_result.get('instructions', 0), instructions_per_second) if official_result.get('instructions', 0) > 0 and instructions_per_second > 0 else official_result.cpu_time %}
-                                    {% set current_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
-                                    {% if official_cpu_time and official_cpu_time >= 0.05 and current_cpu_time %}
-                                        {% set percent_change = ((current_cpu_time - official_cpu_time) / official_cpu_time * 100) | round(0) | int %}
-                                        {% if percent_change > 0 %}+{{ percent_change }}%{% elif percent_change < 0 %}{{ percent_change }}%{% else %}0%{% endif %}
-                                    {% else %}
-                                        👍
-                                    {% endif %}
-                                {% else %}
-                                    👍
-                                {% endif %}
-                            {% else %}
-                                {# Show result status for other tests #}
-                                {% if result.status == 'accepted' %}👍{% elif result.status == 'rejected' %}✋{% elif result.status == 'declined' %}🚫{% else %}💥{% endif %}
-                            {% endif %}
-                        </a>
-                        {% else %}
-                            -
-                        {% endif %}
-                    </td>
-                    {% endif %}
-                {% endfor %}
-                <td class="text-right">{{ test.size_str }}</td>
-            </tr>
+            {% for row in test_rows if not row.is_group %}
+            {{ test_row(row.member, none) }}
             {% endfor %}
         </tbody>
+        {% for row in test_rows if row.is_group %}
+        <tbody class="group">
+            <tr class="group-summary">
+                <td><label title="Click to show the individual tests"><input type="checkbox" class="group-toggle"><span class="group-arrow"></span>{{ row.name }}/ <span class="text-muted">({{ row.count }} tests)</span></label></td>
+                <td class="spacer-col"></td>
+                {% for checker in checkers %}
+                {% if checker.name == 'official' %}{{ group_summary_cell(row.checker_stats[checker.name], true) }}{% endif %}
+                {% endfor %}
+                {% for checker in checkers %}
+                {% if checker.name != 'official' %}{{ group_summary_cell(row.checker_stats[checker.name], false) }}{% endif %}
+                {% endfor %}
+                <td class="text-right">{{ row.size_str }}</td>
+            </tr>
+            {% for test in row.members %}
+            {{ test_row(test, row.name) }}
+            {% endfor %}
+        </tbody>
+        {% endfor %}
     </table>
     </div>
     {% else %}

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -15,3 +15,26 @@ table th, table td {
 th.spacer-col, td.spacer-col {
   width: 100%;
 }
+
+/* Collapsible test group rows: each group is a tbody whose summary row
+   holds a hidden checkbox in a label; the checkbox state shows or hides
+   the remaining rows of the tbody, no JavaScript needed */
+tr.group-summary label {
+  cursor: pointer;
+  display: block;
+}
+tr.group-summary .group-toggle {
+  display: none;
+}
+tbody.group:not(:has(.group-toggle:checked)) tr:not(.group-summary) {
+  display: none;
+}
+tr.group-summary .group-arrow::before {
+  content: "▸ ";
+}
+td.group-member {
+  padding-left: 2.4em;
+}
+tbody.group:has(.group-toggle:checked) .group-arrow::before {
+  content: "▾ ";
+}


### PR DESCRIPTION
Tests in a group (subdirectory) are now summarized as a single row at the
end of the test tables, on the main page (with per-checker correct
counts) and on the per-checker pages (with correct counts, total virtual
time, aggregate comparison against the official checker, and peak
memory). Clicking the row reveals the individual tests, shown indented
and without the group prefix.

Each group is its own <tbody> with a hidden checkbox in the summary row,
so the toggle is pure CSS (via :has()), without JavaScript.

Also mark tests without expected outcome with 🤷 on the main page,
otherwise `either` tests are not recognizable as such in the test table.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D6eedjfpntSKyEKsNPBxb3
