### PR TITLE
Declare declines for mini, evmlean and nyaya to speed up CI

### DIFF
--- a/checkers/evmlean.yaml
+++ b/checkers/evmlean.yaml
@@ -29,3 +29,11 @@ ref: main
 rev: 055a6b9cad082f13838a50ba92a937d347690d13
 build: npm install --no-audit --no-fund && node tools/build.js
 run: node bin/evmlean.js $IN
+# Cannot handle the full Init.Prelude, so decline everything built on top of it
+declines:
+  - init-prelude
+  - init
+  - std
+  - mathlib
+  - cedar
+  - cslib

--- a/checkers/mini.yaml
+++ b/checkers/mini.yaml
@@ -8,3 +8,11 @@ ref: master
 rev: ad8ebe0e061a76b520061800b47bb60c3ce7d81e
 build: lake build
 run: timeout 30s .lake/build/bin/mini-kernel "$IN"
+# Cannot handle the full Init.Prelude, so decline everything built on top of it
+declines:
+  - init-prelude
+  - init
+  - std
+  - mathlib
+  - cedar
+  - cslib

--- a/checkers/nyaya.yaml
+++ b/checkers/nyaya.yaml
@@ -11,3 +11,10 @@ build: |
 run: |
   ulimit -v 1000000 -c 0
   NYAYA_ARENA=1 timeout 30s ./_opam/bin/nyaya "$IN"
+# Cannot handle anything bigger than the init test
+# (init itself is kept to show that it explodes there)
+declines:
+  - std
+  - mathlib
+  - cedar
+  - cslib


### PR DESCRIPTION
Per the arena results, mini and evmlean decline init-prelude and all
tests built on top of it at runtime, and nyaya errors out on everything
bigger than init. Declaring these in the declines field lets the CI
matrix jobs skip building these expensive tests altogether. The init
test is kept for nyaya to show that it explodes there.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D6eedjfpntSKyEKsNPBxb3
