### PR TITLE
Tests for sorts that are Prop up to level normalization

### DIFF
--- a/tests/proj-of-imax-prop.lean
+++ b/tests/proj-of-imax-prop.lean
@@ -1,0 +1,66 @@
+import Lean
+open Lean Elab Command
+
+/-
+A closed proof of `False`, with no axioms, that a kernel accepts iff it tests whether a
+sort is `Prop` only syntactically (the bug fixed in leanprover/lean4#14613).
+
+`ImaxProp : Sort (imax 1 0)` is a proposition, since `imax 1 0` normalizes to `0`. The
+exploit uses two definitionally equal spellings of that type, each hitting the buggy
+syntactic `is_prop` check on the side it needs:
+
+* Proof irrelevance is stated through `ImaxAsProp : Prop := ImaxProp`, whose type is the
+  *literal* `Sort 0`. Even the buggy kernel recognizes this as a proposition, so it equates
+  `imaxLeft := ImaxProp.mk false` and `imaxRight := ImaxProp.mk true`.
+
+* The data projection `imaxProjBool : ImaxProp → Bool` is stated on `ImaxProp` directly,
+  whose type is the *literal* `Sort (imax 1 0)`. The buggy kernel does not recognize this
+  as a proposition and so wrongly permits projecting the `Bool` field out of a proof.
+
+Combining them, `imaxProjBool imaxLeft` and `imaxProjBool imaxRight` reduce to `false` and
+`true`, yet are equal by congruence on the proof-irrelevance equation — hence `False`.
+
+The companion `ImaxPropDummy` in the same mutual block is needed for the `Bool` field to be
+accepted: the kernel checks constructor field universes against the resulting level of the
+*first* inductive of the block, and does not recognize the unnormalized `Sort (imax 1 0)`
+as a `Prop` (whose fields may come from any universe).
+-/
+
+run_cmd liftTermElabM do
+  addDecl <| .inductDecl [] 0 [
+    { name := `ImaxPropDummy
+      type := .sort 0
+      ctors := [{ name := `ImaxPropDummy.intro, type := .const `ImaxPropDummy [] }] },
+    { name := `ImaxProp
+      type := .sort (.imax 1 0)
+      ctors := [{ name := `ImaxProp.mk
+                  type := .forallE `value (.const ``Bool []) (.const `ImaxProp []) .default }] }
+  ] false
+
+/-- A `Prop`-ascribed alias: its type is the literal `Sort 0`. -/
+def ImaxAsProp : Prop := ImaxProp
+
+def imaxLeft  : ImaxAsProp := ImaxProp.mk false
+def imaxRight : ImaxAsProp := ImaxProp.mk true
+
+/-- Proof irrelevance via the alias: accepted by any kernel, buggy or fixed. -/
+theorem imaxIrrel : imaxLeft = imaxRight := rfl
+
+/-
+The data projection out of the proposition, which a sound kernel must reject. Added under
+`debug.skipKernelTC` so this file builds regardless of whether the local toolchain has the
+fix; the checker under test replays it and must reject it.
+-/
+run_cmd liftTermElabM do
+  withOptions (debug.skipKernelTC.set · true) do
+    addDecl <| .defnDecl {
+      name := `imaxProjBool
+      levelParams := []
+      type := .forallE `p (.const `ImaxProp []) (.const ``Bool []) .default
+      value := .lam `p (.const `ImaxProp []) (.proj `ImaxProp 0 (.bvar 0)) .default
+      hints := .abbrev
+      safety := .safe }
+
+theorem badFalse : False :=
+  (imaxIrrel ▸ (trivial : cond (imaxProjBool imaxLeft) False True)
+    : cond (imaxProjBool imaxRight) False True)

--- a/tests/proj-of-imax-prop.yaml
+++ b/tests/proj-of-imax-prop.yaml
@@ -1,0 +1,18 @@
+description: |
+  A closed proof of `False`, with no axioms, via a data projection out of a
+  proposition whose sort is `Prop` only up to universe level normalization.
+
+  `ImaxProp : Sort (imax 1 0)` is a proposition, since `imax 1 0` normalizes to `0`.
+  The exploit uses two definitionally equal spellings of that type. Proof
+  irrelevance is stated through `ImaxAsProp : Prop := ImaxProp`, whose type is the
+  literal `Sort 0`, so it is accepted; the data projection `imaxProjBool` is stated
+  on `ImaxProp`, whose type is the literal `Sort (imax 1 0)`. A kernel that tests
+  sorts for `Prop` syntactically does not recognize the latter as a proposition and
+  wrongly allows projecting its `Bool` field out of a proof. Congruence on the
+  proof-irrelevance equation then equates `false` and `true`, giving `False`.
+
+  This is <https://github.com/leanprover/lean4/pull/14613>, a bug in the official
+  kernel.
+leanfile: tests/proj-of-imax-prop.lean
+export-decls: ["badFalse"]
+outcome: reject


### PR DESCRIPTION
Adds a regression test distilled from the kernel bug fixed in
[leanprover/lean4#14613](https://github.com/leanprover/lean4/pull/14613).

## The bug

`type_checker::is_prop` compared `whnf(infer_type e)` against `Prop`
*syntactically*. The level `imax 1 0` is definitionally `0`, so a type in
`Sort (imax 1 0)` really is a proposition, but the syntactic check answers
`false`. As a result `infer_proj` skips its `Prop` restriction and lets a
non-proof (data) field be projected out of a proof — and proof irrelevance
then equates two such proofs, so projecting a `Bool` field out of them yields
`false = true`, hence `False`, with no axiom dependencies.

## The test

`tests/proj-of-imax-prop.{lean,yaml}` exports a closed, axiom-free proof
`badFalse : False` that a buggy kernel accepts. It uses two definitionally
equal spellings of the same type, each hitting the buggy check on the side it
needs:

- **Proof irrelevance** is stated through `ImaxAsProp : Prop := ImaxProp`,
  whose type is the *literal* `Sort 0`, so even the buggy kernel recognizes it
  as a proposition and equates `ImaxProp.mk false` with `ImaxProp.mk true`.
- **The data projection** `imaxProjBool : ImaxProp → Bool` is stated on
  `ImaxProp`, whose type is the *literal* `Sort (imax 1 0)`, where the buggy
  syntactic check fails and wrongly permits the projection.

Congruence on the proof-irrelevance equation then equates `false` and `true`.

The declaration cannot be written in surface syntax (levels are normalized
eagerly), so the projection is added under `debug.skipKernelTC`; the file
therefore builds on both fixed and unfixed toolchains. A companion
`ImaxPropDummy` in the same mutual block is required for the `Bool` field to be
accepted, since the kernel checks constructor field universes against the
resulting level of the block's first inductive.

Because it relies on a mutual inductive, this is a standalone regression test
rather than a tutorial case.

## Verification

- `official` (v4.32.2, fix unreleased): **accepts** the proof of `False` —
  reported incorrect, as expected. Flips to correct once the fix ships.
- `nanoda`: **rejects** it — correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)