### PR TITLE
ci: reapply checker matrix, on Namespace runners with working perf

### DIFF
--- a/.github/checker-matrix.sh
+++ b/.github/checker-matrix.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Selects the checkers to run in CI and prints them as a "checkers=<JSON
+# array>" line, suitable for appending to $GITHUB_OUTPUT.
+#
+# Normally all enabled checkers are selected. On pull requests that touch
+# nothing but checker configurations, only the touched checkers are selected.
+set -euo pipefail
+
+all=$(./lka.py list-checkers --json)
+selected="$all"
+
+if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+  # Diff the PR head commit against its merge base with the target branch.
+  # BASE_SHA and HEAD_SHA are set from the event payload in the workflow;
+  # computing the merge base requires a full-history checkout.
+  changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+  if [ -n "$changed" ] && ! grep -qv '^checkers/[^/]*\.yaml$' <<< "$changed"; then
+    touched=$(sed -e 's!^checkers/!!' -e 's!\.yaml$!!' <<< "$changed" | jq --raw-input . | jq --slurp --compact-output .)
+    # Restrict to the touched checkers, as far as they (still) exist and are
+    # enabled. If none are left (e.g. the PR deletes a checker), fall back to
+    # running all of them.
+    selected=$(jq --compact-output --argjson touched "$touched" 'map(select(. as $c | $touched | index($c)))' <<< "$all")
+    if [ "$selected" = "[]" ]; then
+      selected="$all"
+    fi
+  fi
+fi
+
+echo "Selected checkers: $selected" >&2
+echo "checkers=$selected"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -90,8 +90,19 @@ jobs:
               printf "%s: (missing)\n" "$f"
             fi
           done
-          echo "=== try perf stat (may require privileges) ==="
-          perf stat -e cycles -a -- true 2>&1 || echo "perf stat failed or not permitted"
+          echo "=== software event, own process (works even without PMU) ==="
+          perf stat -e task-clock -- true 2>&1 || echo "software event failed"
+          echo "=== hardware event, own process (allowed at paranoid=2 if a PMU exists) ==="
+          perf stat -e cycles,instructions -- true 2>&1 || echo "hardware event failed"
+          echo "=== try lowering perf_event_paranoid via sudo ==="
+          if sudo sysctl -w kernel.perf_event_paranoid=-1 2>&1; then
+            echo "=== hardware event after sysctl ==="
+            perf stat -e cycles,instructions -- true 2>&1 || echo "hardware event still failing (likely no vPMU)"
+            echo "=== system-wide after sysctl ==="
+            perf stat -e cycles -a -- true 2>&1 || echo "system-wide still failing"
+          else
+            echo "sudo sysctl not permitted"
+          fi
         shell: 'nix develop -c bash -euxo pipefail {0}'
         continue-on-error: true
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -47,7 +47,9 @@ jobs:
   check:
     name: 'Checker: ${{ matrix.checker }}'
     needs: select-checkers
-    runs-on: ubuntu-latest
+    # Namespace runner: unlike GitHub-hosted runners it exposes a vPMU,
+    # so perf instruction counts work (user-space-only at paranoid=2)
+    runs-on: nscloud-ubuntu-22.04-amd64-8x16
     timeout-minutes: 360
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,68 +1,77 @@
 name: Build and Deploy Site
 
 on:
-  workflow_dispatch: # Manual trigger
+  workflow_dispatch: # Manual trigger, also deploys the site
   pull_request: # Run on pull requests
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  create-runner:
-    name: Create Hetzner Cloud runner
+  select-checkers:
+    name: Select checkers
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'  # Only create runner for manual dispatch
     outputs:
-      label: ${{ steps.create-hcloud-runner.outputs.label }}
-      server_id: ${{ steps.create-hcloud-runner.outputs.server_id }}
+      checkers: ${{ steps.select.outputs.checkers }}
     steps:
-      - name: Create runner
-        id: create-hcloud-runner
-        uses: Cyclenerd/hcloud-github-runner@v1.3.0
-        with:
-          mode: create
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
-          server_type: ccx23
-          location: nbg1  # Nuremberg, Germany
-          image: ubuntu-24.04
-          ssh_key: ${{ secrets.HCLOUD_SSH_KEY_ID }}
-
-  build-and-deploy:
-    needs: create-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.create-runner.outputs.label || 'ubuntu-latest' }} # run on custom runner if available, otherwise default
-    if: always() # Run even if create-runner was skipped
-    timeout-minutes: 1440
-    
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    
-    steps:
-      # Workaround for: https://github.com/actions/runner/issues/1864
-      - name: Ensure HOME is defined
-        run: |
-          set -exuo pipefail
-          if [ -z "${HOME:-}" ]; then
-            HOME="$(getent passwd "$(id -u)" | cut -d: -f6)"
-            export HOME
-          fi
-          echo "HOME=$HOME" >> "$GITHUB_ENV"
-
       - name: Checkout repository
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@v7
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history, to compute the merge base of a pull request
+          fetch-depth: 0
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Pages
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/configure-pages@v4
+      - name: Setup nix shell
+        run: "true"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Select checkers to run
+        id: select
+        run: .github/checker-matrix.sh >> "$GITHUB_OUTPUT"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+  check:
+    name: 'Checker: ${{ matrix.checker }}'
+    needs: select-checkers
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        checker: ${{ fromJSON(needs.select-checkers.outputs.checkers) }}
+    env:
+      CHECKER: ${{ matrix.checker }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup nix shell
         run: "true"
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
+
       - name: Check perf support
         run: |
           echo "=== System info ==="
@@ -85,19 +94,53 @@ jobs:
           perf stat -e cycles -a -- true 2>&1 || echo "perf stat failed or not permitted"
         shell: 'nix develop -c bash -euxo pipefail {0}'
         continue-on-error: true
-      
-      - name: Build checkers
-        run: ./lka.py build-checker
+
+      - name: Build checker
+        run: ./lka.py build-checker "$CHECKER"
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
       - name: Generate tests
-        run: ./lka.py build-test ${{ github.event_name != 'workflow_dispatch' && '--skip-ci' || '' }}
+        run: ./lka.py build-test --skip-declined-by "$CHECKER" ${{ github.event_name != 'workflow_dispatch' && '--skip-ci' || '' }}
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
-      - name: Run checkers on tests
-        run: ./lka.py run
+
+      - name: Run checker on tests
+        run: ./lka.py run --checker "$CHECKER"
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
+
+      - name: Stage results for upload
+        run: ./lka.py ci-pack --outdir /tmp/artifact --results
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: results-${{ matrix.checker }}
+          path: /tmp/artifact
+
+  tutorial:
+    name: Build tutorial page
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup nix shell
+        run: "true"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Build tutorial tests
+        run: ./lka.py build-test tutorial
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
       - name: Build tutorial test viewer
         run: |
           cd test-printer
@@ -105,12 +148,122 @@ jobs:
           lake exe test-printer ../_build/tests/tutorial/ ../_out/tutorial/index.html
         shell: 'nix develop -c bash -euxo pipefail {0}'
 
-      - name: Generate website
-        run: ./lka.py build-site
+      - name: Upload tutorial page
+        uses: actions/upload-artifact@v7
+        with:
+          name: tutorial-page
+          path: _out/tutorial
+
+  test-stats:
+    name: Build test stats and tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup nix shell
+        run: "true"
         shell: 'nix develop -c bash -euxo pipefail {0}'
-      
+
+      - name: Generate tests
+        run: ./lka.py build-test ${{ github.event_name != 'workflow_dispatch' && '--skip-ci' || '' }}
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Build test tarball
+        run: ./lka.py build-tarball
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Stage test stats for upload
+        run: ./lka.py ci-pack --outdir /tmp/artifact --test-stats
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Upload test stats
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-stats
+          path: /tmp/artifact
+
+      - name: Upload test tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-tarball
+          path: _out/lean-arena-tests.tar.gz
+
+  build-site:
+    name: Build and deploy site
+    needs: [check, tutorial, test-stats]
+    if: ${{ !cancelled() && needs.check.result != 'skipped' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # On pull requests, check out the PR head instead of the artificial
+          # merge commit (empty ref means default behavior otherwise)
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Pages
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/configure-pages@v6
+
+      - name: Setup nix shell
+        run: "true"
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Fetch checker results
+        uses: actions/download-artifact@v8
+        with:
+          pattern: results-*
+          path: _artifacts
+
+      - name: Fetch test stats
+        uses: actions/download-artifact@v8
+        with:
+          name: test-stats
+          path: _artifacts/test-stats
+
+      - name: Merge checker results and test stats
+        run: ./lka.py ci-merge _artifacts/*
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
+      - name: Fetch tutorial page
+        uses: actions/download-artifact@v8
+        with:
+          name: tutorial-page
+          path: _out/tutorial
+
+      - name: Fetch test tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: test-tarball
+          path: _tarball
+
+      - name: Generate website
+        run: ./lka.py build-site --tarball _tarball/lean-arena-tests.tar.gz
+        shell: 'nix develop -c bash -euxo pipefail {0}'
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '_out'
 
@@ -128,22 +281,4 @@ jobs:
       - name: Deploy to GitHub Pages
         if: github.event_name == 'workflow_dispatch'
         id: deployment
-        uses: actions/deploy-pages@v4
-
-
-  delete-runner:
-    name: Delete Hetzner Cloud runner
-    needs:
-      - create-runner
-      - build-and-deploy
-    runs-on: ubuntu-latest
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.create-runner.result != 'skipped' }} # Only delete if runner was created
-    steps:
-      - name: Delete runner
-        uses: Cyclenerd/hcloud-github-runner@v1
-        with:
-          mode: delete
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
-          name: ${{ needs.create-runner.outputs.label }}
-          server_id: ${{ needs.create-runner.outputs.server_id }}
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The following resources may be useful:
 * The thesis [The Type Theory of Lean](https://github.com/digama0/lean-type-theory/releases) by Mario Carneiro is a thorough description of Lean's theory.
 * The book [Type Checking in Lean4](https://ammkrn.github.io/type_checking_in_lean4/) by Chris Bailey has good advice on on writing a Lean kernel.
 * On the [arena website](https://arena.lean-lang.org/) you can download a zipfile with the arena tests (excluding large ones).
+* The arena website also publishes a machine-readable `results.json` with all checker metadata, test metadata and individual results, useful for further analysis.
 * The [source of the tutorial tests](https://github.com/leanprover/lean-kernel-arena/blob/master/tutorial/Tutorial.lean) suggests a sequence in which to implement tests.
 
 To add a new checker implementation:

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
           libffi
           libffi.dev
           pkg-config
+          jq
           just
           pypy
           monolith

--- a/lka.py
+++ b/lka.py
@@ -11,6 +11,7 @@
 
 import argparse
 import datetime
+import filecmp
 import fnmatch
 import json
 import os
@@ -49,6 +50,10 @@ _configure_stdout_stderr_unbuffered()
 
 # Global verbose flag
 VERBOSE = False
+
+# Tests with .ndjson files larger than this are excluded from the downloadable
+# test tarball.
+TEST_SIZE_LIMIT = 10 * 1024 * 1024
 
 # Timing/measurement utilities
 
@@ -1070,6 +1075,18 @@ def cmd_build_test(args: argparse.Namespace) -> int:
         if skipped_count > 0:
             print(f"Skipping {skipped_count} test(s) due to --skip-ci flag")
 
+    # Filter out tests that the given checker declaratively declines
+    if args.skip_declined_by:
+        checker = find_checker_by_name(args.skip_declined_by)
+        if checker is None:
+            print(f"No checker found: {args.skip_declined_by}")
+            return 1
+        declines = set(checker.get("declines", []))
+        skipped = [test["name"] for test in tests if test["name"] in declines]
+        if skipped:
+            tests = [test for test in tests if test["name"] not in declines]
+            print(f"Skipping {len(skipped)} test(s) declined by {checker['name']}: {', '.join(skipped)}")
+
     if not tests:
         print("No tests found.")
         return 0
@@ -1167,6 +1184,29 @@ def cmd_build_checker(args: argparse.Namespace) -> int:
 # =============================================================================
 
 
+def write_declined_result(checker_name: str, test_name: str, results_dir: Path) -> dict:
+    """Record a declaratively declined (checker, test) pair without running the checker."""
+    result_data = {
+        "checker": checker_name,
+        "test": test_name,
+        "status": "declined",
+        "correctness": "declined",
+        "exit_code": 2,
+        "wall_time": 0,
+        "cpu_time": 0,
+        "max_rss": 0,
+        "instructions": 0,
+        "stdout": "",
+        "stderr": "Declined via the `declines` field in the checker configuration; the checker was not run.",
+    }
+    results_dir.mkdir(parents=True, exist_ok=True)
+    safe_test_name = test_name.replace("/", "_")
+    result_file = results_dir / f"{checker_name}_{safe_test_name}.json"
+    with open(result_file, "w") as f:
+        json.dump(result_data, f, indent=2)
+    return result_data
+
+
 def run_checker_on_test(checker: dict, test: dict, build_dir: Path, tests_dir: Path, results_dir: Path) -> dict:
     """Run a checker on a test and return the result."""
     checker_name = checker["name"]
@@ -1175,30 +1215,12 @@ def run_checker_on_test(checker: dict, test: dict, build_dir: Path, tests_dir: P
 
     # Tests listed in the checker's `declines` are declined without running
     if test_name in checker.get("declines", []):
-        result_data = {
-            "checker": checker_name,
-            "test": test_name,
-            "status": "declined",
-            "correctness": "declined",
-            "exit_code": 2,
-            "wall_time": 0,
-            "cpu_time": 0,
-            "max_rss": 0,
-            "instructions": 0,
-            "stdout": "",
-            "stderr": "Declined via the `declines` field in the checker configuration; the checker was not run.",
-        }
-        results_dir.mkdir(parents=True, exist_ok=True)
-        safe_test_name = test_name.replace("/", "_")
-        result_file = results_dir / f"{checker_name}_{safe_test_name}.json"
-        with open(result_file, "w") as f:
-            json.dump(result_data, f, indent=2)
-        return result_data
+        return write_declined_result(checker_name, test_name, results_dir)
 
     # Use the file path stored in the test dict
-    test_file = test["file"]
+    test_file = test.get("file")
 
-    if not test_file.exists():
+    if test_file is None or not test_file.exists():
         result_data = {
             "checker": checker_name,
             "test": test_name,
@@ -1366,6 +1388,18 @@ def cmd_run_checker(args: argparse.Namespace) -> int:
             
             print(f"[{status_emoji} {correctness_emoji} {format_duration(result['wall_time'])}]")
 
+        # Also record declaratively declined tests that are not among the
+        # built tests (e.g. because `build-test --skip-declined-by` skipped
+        # building them).
+        built_test_names = {test["name"] for test in tests}
+        for declined_name in checker.get("declines", []):
+            if declined_name in built_test_names:
+                continue
+            if args.test and not fnmatch.fnmatch(declined_name, args.test):
+                continue
+            print(f"Declining {declined_name} for {checker['name']} (declared in checker configuration) [⊘]")
+            results.append(write_declined_result(checker["name"], declined_name, results_dir))
+
     # Summary
     print("\n" + "=" * 60)
     print("Summary:")
@@ -1438,14 +1472,13 @@ def load_tests() -> list[dict]:
             with open(stats_file, "r") as f:
                 test_data = json.load(f)
 
-            # Determine the corresponding .ndjson file path based on stats file location
+            # Determine the corresponding .ndjson file path based on stats file location.
+            # The .ndjson file may be absent, e.g. when only the stats files were
+            # fetched from a CI artifact; such tests can still be shown on the
+            # website, but not be run or included in the tarball.
             ndjson_file = stats_file.parent / (stats_file.stem.replace('.stats', '') + '.ndjson')
-            if ndjson_file.exists():
-                # Add the file path that callers expect
-                test_data["file"] = ndjson_file
-                tests.append(test_data)
-            else:
-                print(f"Warning: No corresponding .ndjson file for {stats_file}")
+            test_data["file"] = ndjson_file if ndjson_file.exists() else None
+            tests.append(test_data)
 
         except Exception as e:
             print(f"Warning: Could not read stats file {stats_file}: {e}")
@@ -1666,13 +1699,14 @@ def create_test_tarball(tests: list, output_dir: Path) -> dict:
 
     with tarfile.open(tarball_path, "w:gz") as tar:
         for test in tests:
-            # Skip tests larger than 10 MB
-            if test.get("size", 0) > 10*1024*1024:
+            # Skip tests larger than the size limit
+            if test.get("size", 0) > TEST_SIZE_LIMIT:
                 continue
 
-            # Use the file path from test data
-            test_file = test["file"]
-            if not test_file.exists():
+            # Use the file path from test data (may be absent for tests whose
+            # stats came from a CI artifact without the .ndjson file)
+            test_file = test.get("file")
+            if test_file is None or not test_file.exists():
                 continue
 
             outcome = test.get("outcome", "unknown")
@@ -1699,6 +1733,39 @@ def create_test_tarball(tests: list, output_dir: Path) -> dict:
         "good_count": good_count,
         "bad_count": bad_count
     }
+
+
+def tarball_info_from_file(tarball_path: Path) -> dict:
+    """Derive tarball statistics (as returned by create_test_tarball) from an
+    existing tarball file."""
+    import tarfile
+
+    good_count = 0
+    bad_count = 0
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        for member in tar:
+            if member.name.startswith("good/"):
+                good_count += 1
+            elif member.name.startswith("bad/"):
+                bad_count += 1
+
+    return {
+        "tarball_size": tarball_path.stat().st_size,
+        "good_count": good_count,
+        "bad_count": bad_count
+    }
+
+
+def cmd_build_tarball(args: argparse.Namespace) -> int:
+    """Handle the build-tarball command."""
+    output_dir = Path(args.outdir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tests = load_tests()
+    tarball_info = create_test_tarball(tests, output_dir)
+    print(f"Created {output_dir / 'lean-arena-tests.tar.gz'} "
+          f"({tarball_info['good_count']} good tests, {tarball_info['bad_count']} bad tests, "
+          f"{format_memory(tarball_info['tarball_size'])})")
+    return 0
 
 
 def result_virtual_time(result: dict, instructions_per_second: float) -> float:
@@ -1758,8 +1825,9 @@ def collect_results_data() -> dict:
     """Collect checkers, tests, results and build metadata into a single
     JSON-serializable structure.
 
-    This is the content of the published results.json file, so it is a
-    complete description of the site's data.
+    This is the content of the published results.json file, and also the data
+    the website is rendered from, so it is a complete description of the
+    site's data.
     """
     checkers = load_checkers()
     tests = load_tests()
@@ -1779,6 +1847,17 @@ def collect_results_data() -> dict:
     }
 
 
+def cmd_write_results(args: argparse.Namespace) -> int:
+    """Handle the write-results command."""
+    out_file = Path(args.out)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    data = collect_results_data()
+    with open(out_file, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"Wrote {out_file} ({len(data['checkers'])} checkers, {len(data['tests'])} tests, {len(data['results'])} results)")
+    return 0
+
+
 def cmd_build_site(args: argparse.Namespace) -> int:
     """Handle the build-site command."""
     output_dir = Path(args.outdir)
@@ -1794,16 +1873,31 @@ def cmd_build_site(args: argparse.Namespace) -> int:
         autoescape=select_autoescape(),
     )
 
-    checkers = load_checkers()
-    results = load_results()
-    tests = load_tests()
+    # The site is rendered from the results.json data structure, either read
+    # from a previously written file (--results) or collected now.
+    if args.results:
+        with open(args.results, "r") as f:
+            results_data = json.load(f)
+    else:
+        results_data = collect_results_data()
 
     # Publish the raw data alongside the site
     results_json_file = output_dir / "results.json"
     with open(results_json_file, "w") as f:
-        json.dump(collect_results_data(), f, indent=2)
+        json.dump(results_data, f, indent=2)
     results_json_info = {"size": results_json_file.stat().st_size}
     print(f"Generated: {results_json_file}")
+
+    checkers = results_data["checkers"]
+    tests = results_data["tests"]
+    results = {(r["checker"], r["test"]): r for r in results_data["results"]}
+    build_info = results_data.get("meta", {})
+
+    # Attach local .ndjson file paths where available (needed for the test
+    # tarball; deliberately not part of results.json)
+    test_files = {test["name"]: test.get("file") for test in load_tests()}
+    for test in tests:
+        test["file"] = test_files.get(test["name"])
 
     # Calculate global instructions per second from results with both cpu_time and instructions
     total_instructions = 0
@@ -1873,11 +1967,15 @@ def cmd_build_site(args: argparse.Namespace) -> int:
             for checker in checkers
         }
 
-    # Get build metadata
-    build_info = get_build_metadata()
-
-    # Create test tarball
-    tarball_info = create_test_tarball(tests, output_dir)
+    # Create the test tarball, or take a pre-built one (see build-tarball)
+    tarball_file = output_dir / "lean-arena-tests.tar.gz"
+    if args.tarball:
+        tarball_src = Path(args.tarball)
+        if tarball_src.resolve() != tarball_file.resolve():
+            shutil.copy2(tarball_src, tarball_file)
+        tarball_info = tarball_info_from_file(tarball_file)
+    else:
+        tarball_info = create_test_tarball(tests, output_dir)
 
     # Build context data
     data = {
@@ -2059,6 +2157,99 @@ def cmd_build_site(args: argparse.Namespace) -> int:
 
 
 # =============================================================================
+# CI support commands
+# =============================================================================
+
+
+def cmd_list_checkers(args: argparse.Namespace) -> int:
+    """Handle the list-checkers command."""
+    names = [checker["name"] for checker in load_checkers()]
+    if args.json:
+        print(json.dumps(names))
+    else:
+        for name in names:
+            print(name)
+    return 0
+
+
+def cmd_ci_pack(args: argparse.Namespace) -> int:
+    """Handle the ci-pack command.
+
+    Stages the selected data, preserving project-relative paths:
+    - --results: all result files from _results/
+    - --test-stats: all test .stats.json files from _build/tests/
+    """
+    if not (args.results or args.test_stats):
+        print("Error: nothing to stage; pass --results and/or --test-stats")
+        return 1
+
+    root = get_project_root()
+    outdir = Path(args.outdir)
+
+    files = []
+    if args.results:
+        results_dir = root / "_results"
+        if results_dir.exists():
+            files.extend(sorted(results_dir.glob("*.json")))
+
+    if args.test_stats:
+        tests_dir = root / "_build" / "tests"
+        if tests_dir.exists():
+            files.extend(sorted(tests_dir.rglob("*.stats.json")))
+
+    for file in files:
+        dest = outdir / file.relative_to(root)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(file, dest)
+
+    print(f"Staged {len(files)} file(s) in {outdir}")
+    return 0
+
+
+def cmd_ci_merge(args: argparse.Namespace) -> int:
+    """Handle the ci-merge command.
+
+    Merges directories staged by ci-pack back into the project, copying each
+    file to its project-relative location. A file that already exists (from a
+    previous artifact or a local build) must be byte-identical; anything else
+    indicates that the CI jobs did not build the same test data, and the merge
+    fails.
+    """
+    root = get_project_root()
+    copied = 0
+    identical = 0
+    conflicts = []
+
+    for dir_str in args.dirs:
+        artifact_dir = Path(dir_str)
+        if not artifact_dir.is_dir():
+            print(f"Error: Not a directory: {artifact_dir}")
+            return 1
+        for file in sorted(path for path in artifact_dir.rglob("*") if path.is_file()):
+            rel = file.relative_to(artifact_dir)
+            dest = root / rel
+            if dest.exists():
+                if filecmp.cmp(file, dest, shallow=False):
+                    identical += 1
+                else:
+                    conflicts.append((rel, artifact_dir))
+            else:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(file, dest)
+                copied += 1
+
+    print(f"Merged {len(args.dirs)} artifact(s): {copied} file(s) copied, {identical} identical duplicate(s)")
+
+    if conflicts:
+        print("Error: The following files differ from an already present copy, but should be identical:")
+        for rel, artifact_dir in conflicts:
+            print(f"  {rel} (from {artifact_dir})")
+        return 1
+
+    return 0
+
+
+# =============================================================================
 # Main entry point
 # =============================================================================
 
@@ -2092,6 +2283,11 @@ def main() -> int:
         "--skip-ci",
         action="store_true",
         help="Skip tests marked with 'skip-on-ci: true' in YAML",
+    )
+    build_test_parser.add_argument(
+        "--skip-declined-by",
+        metavar="CHECKER",
+        help="Skip tests listed in the given checker's 'declines' field",
     )
 
     # build-checker command
@@ -2129,6 +2325,81 @@ def main() -> int:
         default="_out",
         help="Output directory for the website (default: _out)",
     )
+    build_site_parser.add_argument(
+        "--results",
+        metavar="FILE",
+        help="Render the site from a previously written results.json instead of collecting the data (see write-results)",
+    )
+    build_site_parser.add_argument(
+        "--tarball",
+        metavar="FILE",
+        help="Use a pre-built test tarball instead of creating one (see build-tarball)",
+    )
+
+    # build-tarball command
+    build_tarball_parser = subparsers.add_parser(
+        "build-tarball",
+        help="Create the downloadable test tarball from the built tests",
+    )
+    build_tarball_parser.add_argument(
+        "--outdir",
+        default="_out",
+        help="Output directory for the tarball (default: _out)",
+    )
+
+    # write-results command
+    write_results_parser = subparsers.add_parser(
+        "write-results",
+        help="Write all checker/test metadata and results into a single results.json file",
+    )
+    write_results_parser.add_argument(
+        "--out",
+        default="_build/results.json",
+        help="Output file (default: _build/results.json)",
+    )
+
+    # list-checkers command
+    list_checkers_parser = subparsers.add_parser(
+        "list-checkers",
+        help="List all enabled checkers",
+    )
+    list_checkers_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as a JSON array",
+    )
+
+    # ci-pack command
+    ci_pack_parser = subparsers.add_parser(
+        "ci-pack",
+        help="Stage results and test metadata for upload as a CI artifact",
+    )
+    ci_pack_parser.add_argument(
+        "--outdir",
+        required=True,
+        help="Directory to stage the files in",
+    )
+    ci_pack_parser.add_argument(
+        "--results",
+        action="store_true",
+        help="Stage the result files from _results/",
+    )
+    ci_pack_parser.add_argument(
+        "--test-stats",
+        action="store_true",
+        help="Stage the test .stats.json files from _build/tests/",
+    )
+
+    # ci-merge command
+    ci_merge_parser = subparsers.add_parser(
+        "ci-merge",
+        help="Merge CI artifact directories (created by ci-pack) back into the project, checking that duplicate files are identical",
+    )
+    ci_merge_parser.add_argument(
+        "dirs",
+        nargs="+",
+        help="Artifact directories to merge",
+    )
 
     args = parser.parse_args()
 
@@ -2147,6 +2418,16 @@ def main() -> int:
         return cmd_run_checker(args)
     elif args.command == "build-site":
         return cmd_build_site(args)
+    elif args.command == "write-results":
+        return cmd_write_results(args)
+    elif args.command == "build-tarball":
+        return cmd_build_tarball(args)
+    elif args.command == "list-checkers":
+        return cmd_list_checkers(args)
+    elif args.command == "ci-pack":
+        return cmd_ci_pack(args)
+    elif args.command == "ci-merge":
+        return cmd_ci_merge(args)
     else:
         parser.print_help()
         return 1

--- a/lka.py
+++ b/lka.py
@@ -285,7 +285,9 @@ def measure_perf_with_fallback(
                             try:
                                 data = json.loads(line)
                                 if "event" in data and "counter-value" in data:
-                                    event = data["event"]
+                                    # Strip modifiers like ":u" that perf appends when it
+                                    # falls back to user-space-only counting (perf_event_paranoid=2)
+                                    event = data["event"].split(":")[0]
                                     value = float(data["counter-value"])
                                     unit = data.get("unit", "")
 


### PR DESCRIPTION
Reapplies the GitHub Actions matrix parallelization (#95), reverted in #100 because instruction counts were missing on GitHub-hosted runners, and moves the per-checker matrix jobs to Namespace runners (\`nscloud-ubuntu-22.04-amd64-8x16\`), whose VMs expose a vPMU. All other jobs stay on \`ubuntu-latest\`.

Two bugs hid the real story and are fixed here:

- The CI probe only tried system-wide counting (\`perf stat -a\`), which \`perf_event_paranoid >= 1\` forbids even when per-process counting (all that \`lka.py\` needs) works. The probe now tests software and hardware events on the own process and retries after a sudo sysctl, distinguishing permission problems from a missing vPMU.
- At \`perf_event_paranoid = 2\`, perf falls back to user-space-only counting and reports events as \`task-clock:u\` / \`instructions:u\`; the exact-name matching in \`lka.py\` silently dropped these, yielding \`cpu_time = 0\` and \`instructions = 0\`. The parser now strips the modifier suffix.

With the fixed probe, GitHub-hosted runners turned out to genuinely lack a vPMU (hardware events fail even after lowering \`perf_event_paranoid\`), so working instruction counts do require the Namespace runners. On those, per-process user-space counting works at the default \`paranoid = 2\` with no sysctl needed, as verified on an earlier test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8V39PLAKbpoG7ctgCFhbp