### PR TITLE
Test: reject declarations naming the kernel's _nested aux types

### DIFF
--- a/tests/nested-aux-name.lean
+++ b/tests/nested-aux-name.lean
@@ -1,0 +1,47 @@
+import Lean
+open Lean Elab Command
+
+/-
+A declaration that names one of the kernel's `_nested` auxiliary types, which a
+correct kernel must reject — the check added in leanprover/lean4#14616. This is
+*not* a proof of `False`: the declaration is perfectly well-typed, so a kernel
+lacking the guard accepts it. It only exercises the reserved-prefix check, the
+same thing the upstream test `tests/elab/kernelNestedAuxName.lean` verifies.
+
+The kernel creates auxiliary types under the `_nested` prefix while eliminating
+nested inductives; they exist only in a temporary environment. A user
+declaration that names such a type is reaching into that machinery, where
+`restore_nested` can later give a stored constructor a type it was never checked
+against (in a different universe), which is unsound. The kernel therefore
+forbids the reserved prefix in `add_inductive` outright, for both `Expr.const`
+names and `Expr.proj` structure names.
+
+Here `_nested.KNHost_1` is an ordinary `Prop`-valued constant (a plain `def`, so
+it is accepted by every kernel — the guard lives only in `add_inductive`). The
+inductive `KNAux : Prop` names it in a constructor field; the field type is just
+`True`, so the whole declaration is well-typed. A guarded kernel rejects `KNAux`
+for using the reserved `_nested` prefix; an unguarded kernel accepts it.
+-/
+
+-- An ordinary constant that merely lives under the reserved `_nested` prefix.
+run_cmd liftTermElabM do
+  addDecl <| .defnDecl {
+    name := `_nested.KNHost_1
+    levelParams := []
+    type := .sort .zero
+    value := .const ``True []
+    hints := .abbrev
+    safety := .safe }
+
+-- `KNAux : Prop` whose constructor field names `_nested.KNHost_1`. Added under
+-- `debug.skipKernelTC` so this file builds regardless of whether the local
+-- toolchain already has the #14616 guard; the checker under test replays the
+-- export and must reject it.
+run_cmd liftTermElabM do
+  withOptions (debug.skipKernelTC.set · true) do
+    addDecl <| .inductDecl [] 0 [
+      { name := `KNAux
+        type := .sort .zero
+        ctors := [{ name := `KNAux.mk
+                    type := .forallE `x (.const `_nested.KNHost_1 [])
+                              (.const `KNAux []) .default }] }] false

--- a/tests/nested-aux-name.yaml
+++ b/tests/nested-aux-name.yaml
@@ -1,0 +1,28 @@
+description: |
+  A declaration that names one of the kernel's `_nested` auxiliary types, which
+  a correct kernel must reject (the check added in leanprover/lean4#14616). This
+  is not a proof of `False`: the declaration is well-typed, so a kernel lacking
+  the guard accepts it — it only exercises the reserved-prefix check.
+
+  The kernel generates auxiliary types under the `_nested` prefix while
+  eliminating nested inductives; they live only in a temporary environment. A
+  user declaration naming one reaches into that machinery, where `restore_nested`
+  can later hand a stored constructor a type in a different universe than it was
+  checked against. The kernel therefore rejects the reserved `_nested` prefix in
+  `add_inductive`, for both constant names and projection structure names.
+
+  `_nested.KNHost_1` here is an ordinary `Prop`-valued `def` (accepted by every
+  kernel; the guard is only in `add_inductive`). `KNAux : Prop` names it in a
+  constructor field of type `True`, so `KNAux` is well-typed; a guarded kernel
+  rejects it for the reserved prefix, an unguarded one accepts it.
+
+  Scaled-down counterpart to the full unsoundness: the axiom-free proof of
+  `False` that this bug also enables relies on transient in-kernel state (the
+  `equiv_manager` defeq cache) that is not reconstructed on a fresh replay of an
+  export, so it cannot be captured as an export-based arena test. This test
+  instead mirrors the upstream regression test
+  `tests/elab/kernelNestedAuxName.lean` from
+  <https://github.com/leanprover/lean4/pull/14616>.
+leanfile: tests/nested-aux-name.lean
+export-decls: ["KNAux"]
+outcome: reject


### PR DESCRIPTION
Scaled-down regression test for the kernel bug fixed in
leanprover/lean4#14616. A declaration that names one of the kernel's
_nested auxiliary types must be rejected by a correct kernel (the fix
adds a reserved-prefix check in add_inductive, covering both Expr.const
names and Expr.proj structure names).

This is deliberately NOT a proof of False. The bug's axiom-free False
relies on transient in-kernel state (the equiv_manager defeq cache) that
is not reconstructed on a fresh replay of an export, so it cannot be
captured as an export-based arena test: the same buggy official kernel
that accepts the exploit in-memory rejects the exported form. Instead,
this mirrors the upstream test tests/elab/kernelNestedAuxName.lean.

tests/nested-aux-name.{lean,yaml} export a well-typed inductive KNAux
whose constructor field names the ordinary Prop-valued def
_nested.KNHost_1. Because KNAux is well-typed, an unguarded kernel
accepts it; a guarded kernel rejects it for the reserved _nested prefix.

Verified: official (v4.32.1, guard unreleased) accepts the exported
KNAux -- reported incorrect, as expected; flips to correct once the fix
ships. Uses metaprogramming (skipKernelTC), so a standalone test.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N8V39PLAKbpoG7ctgCFhbp
