### PR TITLE
Tutorial: the type of an axiom has to be a type

### DIFF
--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -52,6 +52,20 @@ bad_decl (.defnDecl {
 /-- The type of a declaration has to be a type, not some other expression -/
 bad_def nonTypeType : constType := unchecked Prop
 
+/--
+This applies to axioms as well, which are easy to overlook because they have no
+value to check the type against. Letting one through is not merely untidy: an
+axiom whose type is an arbitrary term inhabits whatever that term is later found
+definitionally equal to, and the eta and proof irrelevance rules are happy to
+equate a term like this with a great many things.
+-/
+bad_decl (.axiomDecl {
+  name := `nonTypeAxiom
+  levelParams := []
+  type := Lean.mkConst ``constType
+  isUnsafe := false
+})
+
 /-- The type of a theorem has to be a proposition -/
 bad_decl (.thmDecl {
   name := `nonPropThm


### PR DESCRIPTION
Right after nonTypeType, which makes the same point for definitions. Axioms are
easy to overlook because there is no value to check the type against, so a
kernel can end up inferring the type of the type and never requiring the result
to be a sort.

It is not merely untidy. An axiom whose type is an arbitrary term inhabits
whatever that term is later found definitionally equal to, and the eta and
proof irrelevance rules are generous about that: with a term like
`P.mk True.intro` on one side, structure eta compares `P.mk`'s fields against
projections of the other side, and proof irrelevance answers "equal" for the
proof field without ever looking at that projection. `False` then follows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W5Gm8B4zf82hatvaDBKbV7
