### PR TITLE
chore: bump cslib rev

### DIFF
--- a/tests/cslib.yaml
+++ b/tests/cslib.yaml
@@ -2,7 +2,7 @@ description: |
   The Lean Computer Science Library (CSLib). 
 url: https://github.com/leanprover/cslib
 ref: main
-rev: d1dbe1ec53e08957ff4cb893d82f3e0f7eaa4b00
+rev: c7944a9fb44c3298f1a960a5e574ab23a6ab8ed5
 pre-build: lake exe cache get
 module: Cslib
 outcome: accept


### PR DESCRIPTION
Cslib is flaky when building, the last two builds have had it fail on one checker, most likely due to https://github.com/leanprover/lean4/pull/13027. Bump to v4.30.0.
