### PR TITLE
site: improve relative perf display

### DIFF
--- a/lka.py
+++ b/lka.py
@@ -131,6 +131,22 @@ def format_unitless(count: int) -> str:
         return str(count)
 
 
+def format_relative_perf(current: float, baseline: float) -> str:
+    """Format performance relative to a baseline.
+
+    Changes between -50% and +100% are shown as a percentage; larger changes
+    as a factor (e.g. ÷3.5 for improvements, ×2.3 for regressions), which is
+    more legible than -99% or +470%.
+    """
+    ratio = current / baseline
+    if ratio < 0.5 or ratio > 2:
+        factor = 1 / ratio if ratio < 1 else ratio
+        factor_str = f"{factor:.0f}" if factor >= 10 else f"{factor:.1f}"
+        return ("÷" if ratio < 1 else "×") + factor_str
+    percent = round((ratio - 1) * 100)
+    return f"+{percent}%" if percent > 0 else f"{percent}%"
+
+
 def format_instructions(instruction_count: int) -> str:
     """Format instruction count to a human-readable string with SI prefixes."""
     if instruction_count >= 1_000_000_000:
@@ -1874,6 +1890,7 @@ def cmd_build_site(args: argparse.Namespace) -> int:
         loader=FileSystemLoader(templates_dir),
         autoescape=select_autoescape(),
     )
+    env.globals["format_relative_perf"] = format_relative_perf
 
     # The site is rendered from the results.json data structure, either read
     # from a previously written file (--results) or collected now.
@@ -2057,16 +2074,18 @@ def cmd_build_site(args: argparse.Namespace) -> int:
                 # over the tests that both checkers accepted
                 own_time = 0.0
                 official_time = 0.0
+                compare_perf = False
                 for r in row["members"]:
                     official = r.get("official")
                     if (r.get("expected") == "accept" and r.get("status") == "accepted"
                             and official and official.get("status") == "accepted"):
                         own_time += result_virtual_time(r, instructions_per_second)
                         official_time += result_virtual_time(official, instructions_per_second)
-                if official_time >= 0.05 and own_time > 0:
-                    row["percent"] = round((own_time - official_time) / official_time * 100)
+                        compare_perf = compare_perf or bool(r["test_stats"].get("compare-perf"))
+                if official_time > 0 and (compare_perf or official_time >= 0.05) and own_time > 0:
+                    row["relative_perf"] = format_relative_perf(own_time, official_time)
                 else:
-                    row["percent"] = None
+                    row["relative_perf"] = None
 
             # Create a copy of checker data with rendered description
             checker_with_rendered_desc = checker.copy()

--- a/templates/checker.html
+++ b/templates/checker.html
@@ -10,7 +10,7 @@
                     {% if result.expected == 'accept' %}👍{% elif result.expected == 'reject' %}✋{% elif result.expected == 'either' %}🤷{% else %}⚠️ {{ result.expected }}{% endif %}
                 </td>
                 {{ result_status_cell(result.expected, result.status) }}
-                {{ perf_cells(result, result.expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time) }}
+                {{ perf_cells(result, result.expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time, result.test_stats.get('compare-perf')) }}
             </tr>
 {% endmacro %}
 
@@ -132,7 +132,7 @@ section pre, details pre {
                     {% if row.time_sum %}<span title="Total over all tests in the group">{{ format_duration(row.time_sum) }}</span>{% endif %}
                 </td>
                 <td class="text-left">
-                    {% if row.percent is not none %}({% if row.percent > 0 %}+{% endif %}{{ row.percent }}%){% endif %}
+                    {% if row.relative_perf is not none %}({{ row.relative_perf }}){% endif %}
                 </td>
                 <td class="text-right">
                     {% if row.rss_max %}<span title="Maximum over all tests in the group">{{ format_memory(row.rss_max) }}</span>{% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,9 +47,8 @@
                                 {% if official_result and official_result.status == 'accepted' %}
                                     {% set official_cpu_time = convert_instructions_to_time(official_result.get('instructions', 0), instructions_per_second) if official_result.get('instructions', 0) > 0 and instructions_per_second > 0 else official_result.cpu_time %}
                                     {% set current_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
-                                    {% if official_cpu_time and official_cpu_time >= 0.05 and current_cpu_time %}
-                                        {% set percent_change = ((current_cpu_time - official_cpu_time) / official_cpu_time * 100) | round(0) | int %}
-                                        {% if percent_change > 0 %}+{{ percent_change }}%{% elif percent_change < 0 %}{{ percent_change }}%{% else %}0%{% endif %}
+                                    {% if official_cpu_time and current_cpu_time %}
+                                        {{ format_relative_perf(current_cpu_time, official_cpu_time) }}
                                     {% else %}
                                         👍
                                     {% endif %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -27,8 +27,10 @@
 </td>
 {% endmacro %}
 
-{# Performance cells: time, time%, memory, memory% #}
-{% macro perf_cells(result, expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time) %}
+{# Performance cells: time, time%, memory, memory%.
+   With compare_perf set, comparisons are shown even if the official checker
+   was fast (below the noise thresholds). #}
+{% macro perf_cells(result, expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time, compare_perf=false) %}
 <td class="text-right">
     {% if result.get('instructions', 0) > 0 and instructions_per_second > 0 %}
         <span title="{{ format_instructions(result.get('instructions', 0)) }} instructions">{{ format_duration(convert_instructions_to_time(result.get('instructions', 0), instructions_per_second)) }}</span>
@@ -40,9 +42,8 @@
     {% if expected == 'accept' and result.status == 'accepted' and result.official and result.official.status == 'accepted' %}
         {% set official_cpu_time = convert_instructions_to_time(result.official.get('instructions', 0), instructions_per_second) if result.official.get('instructions', 0) > 0 and instructions_per_second > 0 else result.official.cpu_time %}
         {% set current_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
-        {% if official_cpu_time and official_cpu_time >= 0.05 and current_cpu_time %}
-            {% set percent_change = ((current_cpu_time - official_cpu_time) / official_cpu_time * 100) | round(0) | int %}
-            {% if percent_change > 0 %}(+{{ percent_change }}%){% elif percent_change < 0 %}({{ percent_change }}%){% else %}(0%){% endif %}
+        {% if official_cpu_time and (compare_perf or official_cpu_time >= 0.05) and current_cpu_time %}
+            ({{ format_relative_perf(current_cpu_time, official_cpu_time) }})
         {% endif %}
     {% endif %}
 </td>
@@ -55,9 +56,8 @@
     {% if expected == 'accept' and result.status == 'accepted' and result.official and result.official.status == 'accepted' %}
         {% set official_memory = result.official.max_rss %}
         {% set current_memory = result.max_rss %}
-        {% if official_memory and official_memory >= 200*1024*1024 and current_memory %}
-            {% set percent_change = ((current_memory - official_memory) / official_memory * 100) | round(0) | int %}
-            {% if percent_change > 0 %}(+{{ percent_change }}%){% elif percent_change < 0 %}({{ percent_change }}%){% else %}(0%){% endif %}
+        {% if official_memory and (compare_perf or official_memory >= 200*1024*1024) and current_memory %}
+            ({{ format_relative_perf(current_memory, official_memory) }})
         {% endif %}
     {% endif %}
 </td>

--- a/templates/test.html
+++ b/templates/test.html
@@ -63,7 +63,7 @@
                 <td><a href="{{ root_path }}checker/{{ result.checker }}/#test-{{ test.name }}">{{ result.checker }}</a></td>
                 <td class="spacer-col"></td>
                 {{ result_status_cell(test.outcome, result.status) }}
-                {{ perf_cells(result, test.outcome, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time) }}
+                {{ perf_cells(result, test.outcome, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time, test.get('compare-perf')) }}
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
With more perf tests on the arena, relative performance like -99% is not
informative. Keep percentages only in the range -50% to +100%; beyond
that, show a factor instead (÷3.5 for improvements, ×2.3 for
regressions), via a shared format_relative_perf helper used by the index
page, the checker pages and the group summary rows.

Also show the comparison for tests with an explicit compare-perf field
even when the official checker was below the noise thresholds.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ENJwC59bY4zgsYpnisbB9c
