### PR TITLE
site: green perf highlights and sticky test table header

### DIFF
--- a/lka.py
+++ b/lka.py
@@ -1942,6 +1942,31 @@ def cmd_build_site(args: argparse.Namespace) -> int:
     # Use fixed hardcoded conversion rate of 6 Ginst/s
     instructions_per_second = 6_000_000_000  # 6 billion instructions per second
 
+    # For perf-compared tests, mark the fastest checker (bg-perf-best) and
+    # those at least 10% faster than the official checker (bg-perf-good);
+    # shown as cell backgrounds on the index page
+    for test in tests:
+        if not test.get("compare-perf"):
+            continue
+        times = {}
+        for checker in checkers:
+            result = results.get((checker["name"], test["name"]))
+            if result and result.get("status") == "accepted":
+                time = result_virtual_time(result, instructions_per_second)
+                if time > 0:
+                    times[checker["name"]] = time
+        if not times:
+            continue
+        best = min(times, key=times.get)
+        official_time = times.get("official")
+        for name, time in times.items():
+            if name == "official":
+                continue
+            if name == best:
+                results[(name, test["name"])]["perf_highlight"] = "bg-perf-best"
+            elif official_time and time < 0.9 * official_time:
+                results[(name, test["name"])]["perf_highlight"] = "bg-perf-good"
+
     # Compute stats for each checker
     for checker in checkers:
         checker["stats"] = compute_checker_stats(checker, tests, results)

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@
                     {% if checker.name != 'official' %}
                     {% set key = (checker.name, test.name) %}
                     {% set result = test_results.get(key) %}
-                    <td class="text-center {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
+                    <td class="text-center {% if result %}{% if test.outcome == 'either' %}{% elif (test.outcome == 'accept' and result.status == 'accepted') or (test.outcome == 'reject' and result.status == 'rejected') %}{{ result.get('perf_highlight', '') }}{% elif result.status == 'declined' or result.status == 'error' %}bg-warning{% else %}bg-error{% endif %}{% endif %}">
                         {% if result %}
                         <a href="checker/{{ checker.name }}/#test-{{ test.name }}" style="text-decoration: none; color: inherit; display: block;">
                             {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
@@ -182,7 +182,7 @@ table thead th {
         <h3>Tests</h3>
     </header>
     {% if tests %}
-    <div style="overflow-x:auto">
+    <div class="sticky-table">
     <table class="striped">
         <thead>
             <tr>
@@ -244,6 +244,10 @@ table thead th {
         The time and space measurements refer to the <tt>mathlib</tt> test case, the largest correct test in the suite. 
         The ⏱️ column shows virtual CPU time, calculated from instruction counts using a fixed rate of {{ format_unitless(instructions_per_second|round|int) }}instr/s. 
         This provides consistent performance comparison across different hardware, though it does not reflect parallel processing capabilities that some checkers may use.
+    </p>
+
+    <p>
+        For performance-compared tests (such as the <tt>perf/</tt> group), the cells show the runtime relative to the official checker. A dark green background marks the fastest checker for that test, and a light green background marks checkers that are at least 10% faster than the official checker.
     </p>
 
     <p>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -29,8 +29,14 @@
 
 {# Performance cells: time, time%, memory, memory%.
    With compare_perf set, comparisons are shown even if the official checker
-   was fast (below the noise thresholds). #}
+   was fast (below the noise thresholds). The time comparison cell gets a
+   light green background when the checker is at least 10% faster than the
+   official checker. #}
 {% macro perf_cells(result, expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time, compare_perf=false) %}
+{% set compared = expected == 'accept' and result.status == 'accepted' and result.official and result.official.status == 'accepted' %}
+{% set official_cpu_time = (convert_instructions_to_time(result.official.get('instructions', 0), instructions_per_second) if result.official.get('instructions', 0) > 0 and instructions_per_second > 0 else result.official.cpu_time) if compared else none %}
+{% set current_cpu_time = (convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time) if compared else none %}
+{% set show_comparison = official_cpu_time and (compare_perf or official_cpu_time >= 0.05) and current_cpu_time %}
 <td class="text-right">
     {% if result.get('instructions', 0) > 0 and instructions_per_second > 0 %}
         <span title="{{ format_instructions(result.get('instructions', 0)) }} instructions">{{ format_duration(convert_instructions_to_time(result.get('instructions', 0), instructions_per_second)) }}</span>
@@ -38,13 +44,9 @@
         {{ format_duration(result.cpu_time) }}
     {% endif %}
 </td>
-<td class="text-left">
-    {% if expected == 'accept' and result.status == 'accepted' and result.official and result.official.status == 'accepted' %}
-        {% set official_cpu_time = convert_instructions_to_time(result.official.get('instructions', 0), instructions_per_second) if result.official.get('instructions', 0) > 0 and instructions_per_second > 0 else result.official.cpu_time %}
-        {% set current_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
-        {% if official_cpu_time and (compare_perf or official_cpu_time >= 0.05) and current_cpu_time %}
-            ({{ format_relative_perf(current_cpu_time, official_cpu_time) }})
-        {% endif %}
+<td class="text-left{% if show_comparison and current_cpu_time < official_cpu_time * 0.9 %} bg-perf-good{% endif %}">
+    {% if show_comparison %}
+        ({{ format_relative_perf(current_cpu_time, official_cpu_time) }})
     {% endif %}
 </td>
 <td class="text-right">

--- a/templates/static/style.css
+++ b/templates/static/style.css
@@ -16,6 +16,40 @@ th.spacer-col, td.spacer-col {
   width: 100%;
 }
 
+/* Performance highlighting: dark green marks the fastest checker on a
+   perf-compared test, light green those at least 10% faster than the
+   official checker */
+.bg-perf-best { background-color: #8ed699; }
+.bg-perf-good { background-color: #d4edda; }
+
+/* Results table with sticky header row and name column: the table scrolls
+   inside its own box (position: sticky sticks to the nearest scroll
+   container, which must not be the page as long as the table needs
+   overflow-x). Sticky cells need opaque backgrounds, matching the row
+   stripes of chota's table.striped. */
+.sticky-table {
+  overflow: auto;
+  max-height: 90vh;
+}
+.sticky-table thead th {
+  position: sticky;
+  top: 0;
+  background-color: var(--bg-color, #fff);
+  z-index: 2;
+}
+.sticky-table th:first-child,
+.sticky-table td:first-child {
+  position: sticky;
+  left: 0;
+  background-color: var(--bg-color, #fff);
+}
+.sticky-table table.striped tr:nth-of-type(2n) td:first-child {
+  background-color: var(--bg-secondary-color, #f3f3f6);
+}
+.sticky-table thead th:first-child {
+  z-index: 3;
+}
+
 /* Collapsible test group rows: each group is a tbody whose summary row
    holds a hidden checkbox in a label; the checkbox state shows or hides
    the remaining rows of the tbody, no JavaScript needed */


### PR DESCRIPTION
For perf-compared tests, mark the fastest checker with a dark green cell
background on the index page, and give a light green background to
checkers at least 10% faster than the official checker, on the index
page and on the comparison cells of the checker and test pages. Slower
checkers are deliberately not highlighted; red backgrounds already mean
incorrect results.

Also let the tests table on the index page scroll inside its own box so
that the header row and the test name column stay in view while the data
columns scroll.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ENJwC59bY4zgsYpnisbB9c
