### PR TITLE
tutorial: structure eta and the unit-like rule need a non-recursive structure

### DIFF
--- a/checkers/mini.yaml
+++ b/checkers/mini.yaml
@@ -5,7 +5,7 @@ description: |
   Runs with a 30s timeout.
 url: https://github.com/nomeata/lean-mini-kernel
 ref: master
-rev: ef7ade033cec1a5a0251263c26b9ef10b2969bf5
+rev: 7ea4f55f5a9f27e096ac8a6a0cf4ecb42e8b7759
 build: lake build
 run: timeout 30s .lake/build/bin/mini-kernel "$IN"
 # Cannot handle the full Init.Prelude, so decline everything built on top of it

--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -1094,8 +1094,36 @@ good_def unitEta2.{u} : ∀ (x y : PUnit.{u}), x = y := fun _ _ => rfl
 /-- Unit eta -/
 good_def unitEta3 : ∀ (x y : PUnit.{0}), x = y := fun _ _ => rfl
 
+inductive IndexedUnit : Bool → Type where
+  | mk : IndexedUnit true
+
+/--
+The unit-like rule, which makes any two elements of a single-constructor type with
+no fields definitionally equal, is also restricted to non-recursive structures
+*without indices* (`is_def_eq_unit_like` goes through `is_non_rec_structure`), so it
+does not fire for `IndexedUnit`.
+-/
+bad_def indexedUnitEta : ∀ (x y : IndexedUnit true), x = y :=
+  fun x y => unchecked Eq.refl x
+
 /-- Structure eta -/
 good_def structEta.{u} : ∀ (α β : Type u) (x : α × β), x = ⟨x.1, x.2⟩ ∧ ⟨x.1, x.2⟩ = x:= fun _ _ _ => ⟨rfl, rfl⟩
+
+inductive IndexedSingleton : Bool → Type where
+  | mk : True → IndexedSingleton true
+
+/--
+Structure eta applies only to *non-recursive structures without indices*: the
+official kernel's `is_non_rec_structure` requires `nindices == 0`, so it does not
+fire for `IndexedSingleton` even though that has a single constructor.
+
+Every field of `IndexedSingleton.mk` is a proof, so a kernel that checks only
+"has a single constructor" and then compares the fields against projections
+would have proof irrelevance discharge the remaining goals, and would wrongly
+accept this.
+-/
+bad_def indexedStructEta : ∀ (x : IndexedSingleton true), IndexedSingleton.mk True.intro = x :=
+  fun x => unchecked Eq.refl x
 
 /-! Function eta -/
 


### PR DESCRIPTION
Both rules go through `is_non_rec_structure`, which requires one constructor,
no indices, and no recursive occurrences. The existing `structEta` and `unitEta*`
tests only exercise types that satisfy all three, so a checker that reads the
condition as just "has a single constructor" passes the whole suite.

Add two `bad_def`s that differ from the existing ones only in carrying an index:

  inductive IndexedUnit : Bool → Type where
    | mk : IndexedUnit true

  inductive IndexedSingleton : Bool → Type where
    | mk : True → IndexedSingleton true

Neither `x = y` nor `IndexedSingleton.mk True.intro = x` holds definitionally.
In both cases the constructor carries no data beyond proofs, so a checker that
skips the index check has proof irrelevance discharge whatever field comparisons
remain and accepts. Verified against the official kernel via `Lean.addDecl`,
which rejects both and accepts the index-free counterparts.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Daf8AZSk3n5NQwLfn7onBM
