### PR TITLE
chore: bump nanoclo

### DIFF
--- a/checkers/nanoclo.yaml
+++ b/checkers/nanoclo.yaml
@@ -14,7 +14,7 @@ description: |
   (Anthropic), directed by Sebastian Graf.
 url: https://github.com/sgraf812/nanoclo
 ref: main
-rev: 9c668a6fc6f3786d80f385bf3854aa55e81205cc
+rev: b27e4c5f788717c884020f1dde4bb7193bca2276
 build: |
   cargo build --release
   cat > config.json <<__END__

--- a/checkers/nanoclo.yaml
+++ b/checkers/nanoclo.yaml
@@ -11,7 +11,7 @@ description: |
   (Anthropic), directed by Sebastian Graf.
 url: https://github.com/sgraf812/nanoclo
 ref: main
-rev: 15b3560a7ad931a71c1500ffd6142805344b51c4
+rev: 9c668a6fc6f3786d80f385bf3854aa55e81205cc
 build: |
   cargo build --release
   cat > config.json <<__END__

--- a/checkers/nanoclo.yaml
+++ b/checkers/nanoclo.yaml
@@ -7,6 +7,18 @@ description: |
   entry through skew-binary jump pointers; substitution into a body happens
   only when a type leaves the checker.
 
+  A term is keyed by the bindings it reads rather than by the environment it
+  stands in, so two environments that agree on what a subterm names share one
+  delayed argument and one inferred type for it, however the rest of those
+  environments differ.
+
+  Conversion evaluates both sides into a graph of interned values and unifies
+  by one match per pair. The value representation, the conversion algorithm,
+  and the fast path of the export parser come from
+  [sokonanoda](https://github.com/intgrah/sokonanoda) (Apache-2.0), whose
+  normalization by evaluation follows András Kovács'
+  [smalltt](https://github.com/AndrasKovacs/smalltt).
+
   The modifications from the original nanoda_lib were written by Claude
   (Anthropic), directed by Sebastian Graf.
 url: https://github.com/sgraf812/nanoclo

--- a/checkers/nanoclo.yaml
+++ b/checkers/nanoclo.yaml
@@ -7,17 +7,8 @@ description: |
   entry through skew-binary jump pointers; substitution into a body happens
   only when a type leaves the checker.
 
-  A term is keyed by the bindings it reads rather than by the environment it
-  stands in, so two environments that agree on what a subterm names share one
-  delayed argument and one inferred type for it, however the rest of those
-  environments differ.
-
-  Conversion evaluates both sides into a graph of interned values and unifies
-  by one match per pair. The value representation, the conversion algorithm,
-  and the fast path of the export parser come from
-  [sokonanoda](https://github.com/intgrah/sokonanoda) (Apache-2.0), whose
-  normalization by evaluation follows András Kovács'
-  [smalltt](https://github.com/AndrasKovacs/smalltt).
+  Conversion is [sokonanoda](https://github.com/intgrah/sokonanoda)'s
+  (Apache-2.0), as is the fast path of the export parser.
 
   The modifications from the original nanoda_lib were written by Claude
   (Anthropic), directed by Sebastian Graf.


### PR DESCRIPTION
Points nanoclo at the current `main`, implementing NbE inspired by `sokonanoda`.

On the Mathlib-derived files I measure locally, this rev retires 1.57x to 1.92x fewer instructions than 15b3560.