### PR TITLE
site: key perf comparisons on compare-perf, retire time thresholds

### DIFF
--- a/lka.py
+++ b/lka.py
@@ -2099,15 +2099,13 @@ def cmd_build_site(args: argparse.Namespace) -> int:
                 # over the tests that both checkers accepted
                 own_time = 0.0
                 official_time = 0.0
-                compare_perf = False
                 for r in row["members"]:
                     official = r.get("official")
                     if (r.get("expected") == "accept" and r.get("status") == "accepted"
                             and official and official.get("status") == "accepted"):
                         own_time += result_virtual_time(r, instructions_per_second)
                         official_time += result_virtual_time(official, instructions_per_second)
-                        compare_perf = compare_perf or bool(r["test_stats"].get("compare-perf"))
-                if official_time > 0 and (compare_perf or official_time >= 0.05) and own_time > 0:
+                if official_time > 0 and own_time > 0:
                     row["relative_perf"] = format_relative_perf(own_time, official_time)
                 else:
                     row["relative_perf"] = None

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
                             {% if test.outcome == 'accept' and result.status == 'accepted' and test.get('compare-perf') %}
                                 {# Show absolute virtual time for perf-compared tests #}
                                 {% set official_cpu_time = convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time %}
-                                {% if official_cpu_time and official_cpu_time >= 0.05 %}
+                                {% if official_cpu_time %}
                                     {{ format_duration(official_cpu_time) }}
                                 {% else %}
                                     👍

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -28,15 +28,14 @@
 {% endmacro %}
 
 {# Performance cells: time, time%, memory, memory%.
-   With compare_perf set, comparisons are shown even if the official checker
-   was fast (below the noise thresholds). The time comparison cell gets a
-   light green background when the checker is at least 10% faster than the
-   official checker. #}
+   Comparisons are shown for tests marked compare-perf. The time comparison
+   cell gets a light green background when the checker is at least 10% faster
+   than the official checker. #}
 {% macro perf_cells(result, expected, instructions_per_second, format_duration, format_memory, format_instructions, convert_instructions_to_time, compare_perf=false) %}
 {% set compared = expected == 'accept' and result.status == 'accepted' and result.official and result.official.status == 'accepted' %}
 {% set official_cpu_time = (convert_instructions_to_time(result.official.get('instructions', 0), instructions_per_second) if result.official.get('instructions', 0) > 0 and instructions_per_second > 0 else result.official.cpu_time) if compared else none %}
 {% set current_cpu_time = (convert_instructions_to_time(result.get('instructions', 0), instructions_per_second) if result.get('instructions', 0) > 0 and instructions_per_second > 0 else result.cpu_time) if compared else none %}
-{% set show_comparison = official_cpu_time and (compare_perf or official_cpu_time >= 0.05) and current_cpu_time %}
+{% set show_comparison = compare_perf and official_cpu_time and current_cpu_time %}
 <td class="text-right">
     {% if result.get('instructions', 0) > 0 and instructions_per_second > 0 %}
         <span title="{{ format_instructions(result.get('instructions', 0)) }} instructions">{{ format_duration(convert_instructions_to_time(result.get('instructions', 0), instructions_per_second)) }}</span>
@@ -58,7 +57,7 @@
     {% if expected == 'accept' and result.status == 'accepted' and result.official and result.official.status == 'accepted' %}
         {% set official_memory = result.official.max_rss %}
         {% set current_memory = result.max_rss %}
-        {% if official_memory and (compare_perf or official_memory >= 200*1024*1024) and current_memory %}
+        {% if compare_perf and official_memory and current_memory %}
             ({{ format_relative_perf(current_memory, official_memory) }})
         {% endif %}
     {% endif %}

--- a/tests/init-prelude.yaml
+++ b/tests/init-prelude.yaml
@@ -2,3 +2,4 @@ description: |
   The `Init.Prelude` module export.
 leanfile: tests/init_prelude_module.lean
 outcome: accept
+compare-perf: true

--- a/tests/perf/grind-ring-5.yaml
+++ b/tests/perf/grind-ring-5.yaml
@@ -5,3 +5,4 @@ description: |
 leanfile: tests/perf/grind-ring-5.lean
 export-decls: ["thm", "String.ofList", "Char.ofNat"]
 outcome: accept
+compare-perf: true


### PR DESCRIPTION
The official column now shows the absolute time for all perf-compared
tests, even fast ones. With that, the 0.05s (and 200MB memory) noise
thresholds are retired: individual comparisons are shown if and only if
the test is marked compare-perf, and group summary rows always show the
aggregated comparison.

The two tests that relied on the threshold to get a comparison,
perf/grind-ring-5 and init-prelude, are now marked compare-perf
explicitly (takes effect once the tests are rebuilt).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ENJwC59bY4zgsYpnisbB9c
