### PR TITLE
lean4lean: bump to ecb3b66 (fixes quadratic replay)

### DIFF
--- a/checkers/lean4lean.yaml
+++ b/checkers/lean4lean.yaml
@@ -6,6 +6,6 @@ description: |
   The lean4lean checker checks that primitive definitions from the prelude are as expected, so it is sensitive to the Lean version it is built against. The `arena` branch tracks lean4lean's master and carries its own `lean-toolchain`, which selects that version.
 url: https://github.com/digama0/lean4lean
 ref: arena
-rev: b93fad07164c25545d22f6841810ba3d2ed54a60
+rev: ecb3b6661c14f8147be1069b126c629114baf4a8
 build: lake build lean4lean
 run: .lake/build/bin/lean4lean --import "$IN"


### PR DESCRIPTION
🤖 Bumps the lean4lean checker from `b93fad0` to [`ecb3b66`](https://github.com/digama0/lean4lean/commit/ecb3b6661c14f8147be1069b126c629114baf4a8).

The interesting part is a fix for quadratic behaviour in lean4lean's replay driver, which is what its arena times have mostly been measuring on the larger tests.

`Kernel.Environment.add` is `{ env with constants := env.constants.insert .. }`, and the replay driver holds the environment in its state while a declaration is being added, so the constant map is shared at every insert. The environment it replays into was built with a **stage-1** `SMap` — a plain `HashMap` — so each insert copied the entire bucket array and increfed every entry (and decrefed them all again when the old map died). That makes a replay of `n` declarations quadratic in `n`. Lean's own `mkEmptyEnvironment` switches to stage 2 for exactly this reason, and `finalizeImport` builds its map with `stage₁ := false`, which is why replaying a module on top of its imports — how lean4lean was benchmarked before the arena — never showed this.

Measured locally on a fresh replay of the `Init` export (56k declarations), with type checking disabled so that only the environment work is left, adding the declarations goes from 37s to 0.14s, plus about as much again in the matching frees. The excess grows as roughly `n^2.5` over the range I could measure, so it is much larger on `std` (94k declarations), `cedar`, `cslib` and `mathlib` — on this checkout `std` went from ~346s to ~201s end to end, and I would expect the big tests to move considerably more. My box is noisy and I cannot run `mathlib` on it, so the arena's own numbers will be the real answer.

Two other things ride along in the rebase, since the `arena` branch tracks lean4lean's master:

* the branch moves to Lean **v4.33.0-rc2** (from v4.30.0), which now matches the `official` checker's version;
* a new implementation of the universe level operations is enabled.

Smoke tested at this revision: builds clean, and a v4.33.0-rc2 `Init` export (57,974 declarations) is accepted.
