### PR TITLE
checkers: bump kiota to 84b2fc4

### DIFF
--- a/checkers/kiota.yaml
+++ b/checkers/kiota.yaml
@@ -7,7 +7,7 @@ description: |
 version: "0.1.0"
 url: https://github.com/sankalpsthakur/kiota
 ref: main
-rev: 02faeb429658ad04e31e99883bd5fc9ae0206698
+rev: 84b2fc41919cb56874ea6a4a62361e357d708ed1
 build: cargo build --release
 run: timeout 30s ./target/release/kiota "$IN"
 # Only the large corpora are declined; every short test is run and reported.


### PR DESCRIPTION
Bumps kiota to a revision that fixes both of its remaining false rejects. It now accepts every good test in the tarball and rejects every bad one — 116/116 good, 62/62 bad on a local sweep of the published tarball.

Three changes since the pinned `02faeb4`:

- **Theorem transparency.** Theorem values are now unfolded in defeq and at recursor major premises. This is what `undecidability/subject-reduction-redex` and `perf/grind-ring-5` were stuck on.
- **Substitution memo.** A per-call `(node, depth)` memo in `instantiate`. DAG-shared proof bodies were re-traversed once per occurrence, which had `grind-ring-5` taking 196s; it now takes 2.3s.
- **Context depth in iota.** The constructor-field walk no longer deepens its context while instantiating the binder it just peeled, which had been producing terms with de Bruijn indices uniformly off by one.

Unrelated, in case it is useful: the site build on the `checkers: add kiota` merge commit ([run 31845220746](https://github.com/leanprover/lean-kernel-arena/actions/runs/31845220746)) failed in `Fetch checker results` with a 403 from `actions/download-artifact`, so the published site is still the pre-merge build. Every checker job in that run succeeded, kiota included, so it looks like Actions infrastructure rather than anything in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)