### PR TITLE
Add MathGraph Kernel A6 checker

### DIFF
--- a/checkers/mathgraph-kernel.yaml
+++ b/checkers/mathgraph-kernel.yaml
@@ -1,0 +1,29 @@
+description: |
+  MathGraph Kernel: optimized Lean 4 proof checker by Metalogic Labs / MathGraph,
+  derived from intgrah/sokonanoda (Apache-2.0).
+url: https://github.com/metalogiclabs/mathgraph-kernel
+ref: main
+rev: 07f7d884bdc1bbd0e6d161bf541908cdf9d14e2f
+build: |
+  git clone https://github.com/intgrah/sokonanoda.git upstream
+  cd upstream
+  git checkout 9b4ea12f4cd437d00b6bcd0e34743065c58dea08
+  python3 ../scripts/apply_a6.py
+  cat > config.json <<__END__
+   {
+     "use_stdin": true,
+     "nat_extension": true,
+     "string_extension": true,
+     "unpermitted_axiom_hard_error": false,
+     "unsafe_permit_all_axioms": true,
+     "num_threads": 4
+   }
+  __END__
+  ROOT=$(cd ../../../../.. && pwd)
+  "$ROOT/lka.py" build-test init-prelude
+  RUSTFLAGS="-C target-cpu=native -Cprofile-generate=$PWD/pgo" cargo build --release
+  target/release/sokonanoda config.json < "$ROOT/_build/tests/init-prelude.ndjson" >/dev/null
+  llvm-profdata merge -o "$PWD/pgo/merged.profdata" "$PWD/pgo"
+  RUSTFLAGS="-C target-cpu=native -Cprofile-use=$PWD/pgo/merged.profdata" cargo build --release
+run: |
+  upstream/target/release/sokonanoda upstream/config.json < "$IN" || exit 1


### PR DESCRIPTION
Adds MathGraph Kernel A6 for Lean Kernel Arena benchmarking.

MathGraph Kernel is a small, reproducible performance patch set over `intgrah/sokonanoda`, with provenance preserved in the public release repository.

Release: `metalogiclabs/mathgraph-kernel@07f7d884bdc1bbd0e6d161bf541908cdf9d14e2f`
Upstream base: `intgrah/sokonanoda@9b4ea12f4cd437d00b6bcd0e34743065c58dea08`

Pre-Arena validation of the release reported 161/161 on the frozen semantic corpus with zero declines. Same-runner calibration against the Arena-pinned sokonanoda revision showed a 1.3162× speedup / -23.96% paired median wall-time change, but those numbers are not presented as Arena results; this PR is intended to obtain the authoritative Arena benchmark.

No changes to Arena itself beyond the checker definition.