### PR TITLE
tests: add MathFin (quantitative finance on Mathlib + brownian-motion)

### DIFF
--- a/tests/mathfin.yaml
+++ b/tests/mathfin.yaml
@@ -1,0 +1,40 @@
+description: |
+  [MathFin](https://github.com/formal-applied-math/formal-mathfin), a library of
+  formally verified mathematical finance built on Mathlib and
+  [brownian-motion](https://github.com/RemyDegenne/brownian-motion).
+
+  Most of MathFin imports the `Mathlib` umbrella, so rather than the whole module
+  this test exports the dependency closure of 17 named theorems, spanning the L²
+  Itô integral, Girsanov, martingale representation and the Black-Scholes PDE.
+url: https://github.com/formal-applied-math/formal-mathfin
+ref: main
+rev: 1df87ce9b7b7dfbfc57424cef8cce6cf21d9b12c
+pre-build: lake exe cache get
+module: MathFin
+export-decls:
+  # convex separation / coherent risk
+  - MathFin.exists_pos_separating_of_cone_disjoint_simplex
+  - MathFin.coherentRisk_isLUB
+  # Black-Scholes: PDE via Feynman-Kac, CRR limit, Merton dominance
+  - MathFin.bsV_satisfies_bs_pde_via_feynmanKac
+  - MathFin.binomialPrice_call_tendsto_bs_closed
+  - MathFin.bsV_le_mertonCallPrice
+  # Ito calculus
+  - MathFin.ito_formula_unrestricted
+  - MathFin.ito_formula_td_L2_bddDeriv
+  - MathFin.ito_formula_gbm
+  - MathFin.discountedGBM_eq_itoIntegral
+  - MathFin.BrownianQuadraticVariation.qv_equals_t
+  # change of measure, representation, completeness
+  - MathFin.bs_discounted_isQMartingale
+  - MathFin.itoIntegralCLM_T_surjective_onto_centered
+  - MathFin.exists_replicating_strategy
+  # SDEs
+  - MathFin.SDEExistence.picardMap_contraction
+  - MathFin.IsL2SolutionPair.uniqueness
+  # jump processes
+  - MathFin.assembly_isometry
+  - MathFin.PoissonThinning.markedPoissonMeasure_eq_prod
+outcome: accept
+compare-perf: true
+skip-on-ci: true


### PR DESCRIPTION
adds [MathFin](https://github.com/formal-applied-math/formal-mathfin), an Apache-2.0
library of formally verified mathematical finance built on Mathlib and
RemyDegenne/brownian-motion.

194 of its files import the `Mathlib` umbrella, so exporting the whole module would
mostly be a second copy of the `mathlib` test. this names 17 theorems in
`export-decls` and exports their closure instead, which comes to roughly 600 MB:
convex separation, the L² Itô integral, Girsanov, martingale representation, the
Black-Scholes PDE, SDE existence, the compensated-Poisson integral.

no `sorryAx` in the export and no `native_decide`; the 17 roots are all
`[propext, Classical.choice, Quot.sound]`. brownian-motion carries two `sorry`s
upstream that the closure does not reach, so the build prints two warnings.

MathFin pins v4.32.0, newer than anything currently in the suite. lean4export master
builds against it, but happy to bump our pin if you would rather not carry a third
toolchain.

AI disclosure: MathFin's proofs are written with LLM assistance, mostly Claude Code,
and so was this test file. the output is kernel-checked rather than trusted: CI
builds on every push, and each headline theorem's axioms are pinned with
`#guard_msgs in #print axioms`.
