### PR TITLE
checkers: pin kiota to main @ 8291753 (restore init-prelude)

### DIFF
--- a/checkers/kiota.yaml
+++ b/checkers/kiota.yaml
@@ -6,8 +6,8 @@ description: |
   declined (same policy as mini).
 version: "0.1.0"
 url: https://github.com/sankalpsthakur/kiota
-ref: fix-soundness-and-perf
-rev: 0b42e27261dfb393599743c83d7e12676361b9ec
+ref: main
+rev: 829175371f5becda1b8435639b445cb235ec63f6
 build: cargo build --release
 run: timeout 30s ./target/release/kiota "$IN"
 # Only the large corpora are declined; every short test is run and reported.

--- a/checkers/kiota.yaml
+++ b/checkers/kiota.yaml
@@ -6,8 +6,8 @@ description: |
   declined (same policy as mini).
 version: "0.1.0"
 url: https://github.com/sankalpsthakur/kiota
-ref: main
-rev: 784039f213f3692912aa1122849710fc6e4f9bf9
+ref: fix-soundness-and-perf
+rev: 0b42e27261dfb393599743c83d7e12676361b9ec
 build: cargo build --release
 run: timeout 30s ./target/release/kiota "$IN"
 # Only the large corpora are declined; every short test is run and reported.


### PR DESCRIPTION
#136 landed `784039f`, which the kiota checker job recorded as **176 correct / 5 declined / 2 errors**. Those two errors are `init-prelude` and `grind-ring-5` (unbounded `(ctx.id, ptr)` caches / 30s timeout). That is a step down on ranking key 2.

This retargets kiota to [`8291753`](https://github.com/sankalpsthakur/kiota/commit/829175371f5becda1b8435639b445cb235ec63f6) on **`main`**:
- stays on the `84b2fc4` line that was 116/116 · 62/62
- caps `Nat.rec` peels of literals wider than 24 bits (`UInt32.toNat_shiftLeft` no longer hangs)
- merge of `fix-soundness-and-perf` onto `main` so `git clone --branch main` can still reach the pin after that feature branch is deleted
- does **not** drop the five large-corpus declines until Init actually accepts

Fixes the regression from #136. Does not claim mathlib/Init yet.

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.