### PR TITLE
checkers: update MathGraph with retained jump32 environment lookup

### DIFF
--- a/checkers/mathgraph.yaml
+++ b/checkers/mathgraph.yaml
@@ -14,14 +14,20 @@ description: |
   ablation isolated the retained optimizations. Changes that improved local
   measurements but failed the full semantic gate were discarded.
 
+  This revision adds one retained refinement over the first public MathGraph
+  entry: a fixed-stride 32-entry jump pointer for deep persistent environment
+  lookup. It is applied from the pinned checker revision before the existing
+  PGO build, with the rest of the checker configuration unchanged.
+
   residual → conjecture → minimal refinement → verification → retained
   constraint → new residual
 
   Developed by [Metalogic Labs](https://mathgraph.org/).
 url: https://github.com/metalogiclabs/mathgraph-lean-kernel
-ref: mathgraph
-rev: 1e209dad266d59b4d43cdea189876bc6ea551339
+ref: mathgraph-v2-release
+rev: af4a9432ac432df1dc896032294454ff31a7be6f
 build: |
+  python3 scripts/apply_jump32.py
   cat > config.json <<__END__
    {
      "use_stdin": true,


### PR DESCRIPTION
Updates the existing `mathgraph` checker to the next retained MathGraph revision.

The first public MathGraph entry is pinned at `1e209dad266d59b4d43cdea189876bc6ea551339`. This revision starts from that exact checker state and adds one intervention only: a fixed-stride 32-entry jump pointer for deep persistent `Env::Cons` lookup.

The checker revision is pinned at `metalogiclabs/mathgraph-lean-kernel@af4a9432ac432df1dc896032294454ff31a7be6f`. The build applies the checked-in `scripts/apply_jump32.py` transformation before the unchanged MathGraph PGO recipe.

Pre-submission validation of the same intervention:

- 38/38 sokonanoda unit tests passed in the experimental runs;
- full supported Arena corpus completed for both public MathGraph and jump32 with identical semantic totals: 183 correct + 6 either;
- the private full-corpus wall-time comparison was ~5.5% faster overall for jump32 on that runner;
- the deep `beta-ladder` residual showed a large retained gain, while broader controls were used to reject more complex alternatives.

The purpose of this PR is to let the Arena's official runner provide the decisive instruction-count measurement. If the official result does not improve the existing MathGraph entry, the intervention should not be treated as a retained leaderboard gain.