### PR TITLE
checkers: bump mathgraph to V2 candidate

### DIFF
--- a/checkers/mathgraph.yaml
+++ b/checkers/mathgraph.yaml
@@ -20,7 +20,7 @@ description: |
   Developed by [Metalogic Labs](https://mathgraph.org/).
 url: https://github.com/metalogiclabs/mathgraph-lean-kernel
 ref: mathgraph
-rev: 6d761d72e5a5036b69ddff2bd47e4cbd331dd034
+rev: 3d7585c21242f29fdaa48ae9a16e16c6afe42238
 build: |
   cat > config.json <<__END__
    {

--- a/checkers/mathgraph.yaml
+++ b/checkers/mathgraph.yaml
@@ -20,7 +20,7 @@ description: |
   Developed by [Metalogic Labs](https://mathgraph.org/).
 url: https://github.com/metalogiclabs/mathgraph-lean-kernel
 ref: mathgraph
-rev: 1e209dad266d59b4d43cdea189876bc6ea551339
+rev: 6d761d72e5a5036b69ddff2bd47e4cbd331dd034
 build: |
   cat > config.json <<__END__
    {


### PR DESCRIPTION
Updates mathgraph to the latest retained kernel revision

This fixes the new extra-rec test and includes the latest beta-path optimization. interesting change was eliminating repeated inference work on immediate lambda applications rather than trying to make the repeated forcingcheaper.

Arena CI is green.