### PR TITLE
checkers: pin kiota to main @ 1b53486 (Acc conversion + grind)

### DIFF
--- a/checkers/kiota.yaml
+++ b/checkers/kiota.yaml
@@ -7,9 +7,9 @@ description: |
 version: "0.1.0"
 url: https://github.com/sankalpsthakur/kiota
 ref: main
-rev: 829175371f5becda1b8435639b445cb235ec63f6
+rev: 1b534869e344660f7f2fdc7033fb87cd75a607ae
 build: cargo build --release
-run: timeout 30s ./target/release/kiota "$IN"
+run: timeout 60s ./target/release/kiota "$IN"
 # Only the large corpora are declined; every short test is run and reported.
 declines:
   - init


### PR DESCRIPTION
#137 pinned kiota at `8291753`: **114/116 · 66/66 · 5 declined**. The two completeness misses were `undecidability/alg-conv-trans-acc-left` and `subject-reduction-redex`. `main` then moved to `a8079e3` (assemble₃ / `#3256`), which false-rejected `perf/grind-ring-5`.

This retargets kiota to [`1b53486`](https://github.com/sankalpsthakur/kiota/commit/1b534869e344660f7f2fdc7033fb87cd75a607ae) on **`main`**:

- Acc conversion: unreduced same-const congruence before WHNF so proof irrelevance sees `f 1 a` vs `f 1 (Acc.intro …)` without iota on only the constructor side. Acc.rec majors beta-only unfold theorem wrappers whose value is a constructor. Name component `Acc`, not substring (`lexAccessible`).
- grind-ring-5: cap **consecutive** `n, n-1, …` `bits() >= 20` `Nat.rec` peels at 2048, not a per-declaration budget. `a8079e3`'s global 2048 starved grind's many short `hugeFuel` recs (`_private.Test.0.thm._proof_1_1`). `#3256` still accepts.
- Timeout 60s (was 30s) so grind has headroom on loaded machines. Arena CI grind is **2.57s**.
- Does **not** drop the five large-corpus declines (`init` `std` `mathlib` `cslib` `cedar`) until Init actually accepts. Locally this pin also unblocks Init `#3495` (`utf8EncodeChar_eq_utf8EncodeCharFast`, 12.6s); prefixes 3500/3600 accept; `#4000` `ByteArray.append_assoc` still hangs at 120s.

### Arena CI (this PR, Checker: kiota PASS)

**116 accepted correct · 66 rejected correct · 5 declined · 0 errors.** Completeness 0, soundness 0. (`either` tests are ignored by the rank key; `quot-left` / `quot-left-def` now accept as `either`.)

| Test | CI wall | CI RSS | notes |
|---|---|---|---|
| alg-conv-trans-acc-left | 5ms | 12MB | was ✋ on `8291753` |
| subject-reduction-redex | 5ms | 11MB | was ✋ |
| grind-ring-5 | 2.57s | 824MB | 25.7G instr; was ×3.8 / 8.6s on live pin |
| let-ladder | 1.29s | 886MB | still eager instantiate; mathgraph ≪ this |
| shift-cascade | 0.82s | 501MB | same |
| beta-ladder | 1.75s | 880MB | mathgraph ÷266 vs official |
| init-prelude | 0.13s | 79MB | |
| extra-rec | reject | | `rogue` |
| proj-of-subst-prop | reject | | `expected a sort` |

Still behind mathgraph's **121/121 · 66/66 · 0 declines**. Let-infer (ladders → ~0.02s) is parked: it re-stalls Init `#3494`. Closures stay out until Init accepts.

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.