### PR TITLE
Test: evil recursors making true equalities false

### DIFF
--- a/tests/large-elim-prop-bool.lean
+++ b/tests/large-elim-prop-bool.lean
@@ -3,7 +3,7 @@ import all Lean.Environment
 import Lean
 
 public section
-open Lean Elab Command
+open Lean
 
 /-- Declared as a `Type`, so everything below is ordinary, legal Lean. -/
 inductive NewBool : Type where | tt | ff

--- a/tests/large-elim-prop-bool.lean
+++ b/tests/large-elim-prop-bool.lean
@@ -1,0 +1,36 @@
+module
+import all Lean.Environment
+import Lean
+
+public section
+open Lean Elab Command
+
+/-- Declared as a `Type`, so everything below is ordinary, legal Lean. -/
+inductive NewBool : Type where | tt | ff
+
+/-- Since `NewBool` is a type, its recursor lets us pick a real `Bool` from them -/
+@[expose] noncomputable def pick : NewBool → Bool :=
+  NewBool.rec (motive := fun _ => Bool) true false
+
+/-- The recursor introduces definitional equalities that allow `pick` to be reduced -/
+theorem pick_tt : true = pick .tt  := rfl
+theorem pick_ff : pick .ff = false := rfl
+
+-- Shenanigans
+run_cmd do
+  let some (.inductInfo v) := (← getEnv).find? ``NewBool | throwError "?"
+  let ci : ConstantInfo := .inductInfo { v with type := .sort 0 }
+  modifyEnv fun env =>
+    -- Tell the kernel `NewBool` was a `Prop` all along
+    let env := env.setCheckedSync <| env.checked.get.add ci
+    -- Convince the elaborator to go along with this nonsense
+    { env with
+      base.public.constants.map₁  := env.base.public.constants.map₁.insert ci.name ci
+      base.private.constants.map₁ := env.base.private.constants.map₁.insert ci.name ci }
+
+/-- Because `.tt` and `.ff` are classified by a `Prop`, they're definitionally equal -/
+theorem tt_eq_ff : NewBool.tt = NewBool.ff := rfl
+
+theorem oh_no : true = false := pick_tt.trans $ (congrArg pick tt_eq_ff).trans pick_ff
+
+theorem boom : False := Bool.noConfusion oh_no

--- a/tests/large-elim-prop-bool.yaml
+++ b/tests/large-elim-prop-bool.yaml
@@ -1,0 +1,9 @@
+description: |
+  Proof of `False` by allowing a `Prop` inductive to have the same recursor
+  that the corresponding `Type` inductive would have.
+
+  Proof irrelevance makes .tt = .ff, but `pick` distinguishes between them.
+
+leanfile: tests/large-elim-prop-bool.lean
+export-decls: ["boom"]
+outcome: reject


### PR DESCRIPTION
I think I finally understand what #49 was doing — or rather, I understand **this** test case, and my friendly robot tells me it's similar to what #49 was doing.

Captures an issue with kiota that isn't currently exercised. Fails for rpylean because rpylean accepts bad recursors.