### PR TITLE
chore: bump nanoda version

### DIFF
--- a/checkers/nanoda.yaml
+++ b/checkers/nanoda.yaml
@@ -17,7 +17,7 @@ description: |
   of failure, so they are all repoted as “rejected”.
 url: https://github.com/ammkrn/nanoda_lib
 ref: master
-rev: 6ae1f0cd962f081f6c423454c5da729d841236a7
+rev: 05055695879dfebb6628a67da88ceca6cd6b0421
 build: |
   cargo build --release
   cat > config.json <<__END__


### PR DESCRIPTION
Might also justify an arena test which includes a recursor declaration with `all_inductives := []`, and `all_inductives := [<nonexistent declaration>]`.