### PR TITLE
Tutorial tests for partial and unsafe

### DIFF
--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -1526,7 +1526,9 @@ bad_consts #[`DupInd2]
 Unsafe and partial declarations can't be used in theorems.
 
 Kernels are permitted to automatically reject or decline whenever they see an unsafe or partial declaration (nanoda does this).
-That's reasonable because, if partial or unsafe declarations are unused, `lean4export` will just strip them out.
+That's reasonable if you're using `lean4export` in the common way where you specify specific constants,
+and only the transitive dependencies of those constants are output.
+In that mode, if unsafe or partial declarations aren't used, they simply won't be output at all.
 Other kernels simply ignore unsafe and partial definitions, so any later use of them becomes an undefined constant.
 -/
 

--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -145,14 +145,14 @@ good_def levelMaxAssoc.{u, v, w} :
 /--
 Level equality: `max` is idempotent (`max u u ≈ u`).
 -/
-good_decl 
+good_decl
   -- elaboration would simplify it if we just wrote
   -- def levelMaxIdem : Sort (u + 1) := Sort (max u u)
   (.defnDecl {
     name := `levelMaxIdem
     levelParams := [`u]
     type := .sort (.succ (.param `u))
-    value := .sort (.max (.param `u) (.param `u)) 
+    value := .sort (.max (.param `u) (.param `u))
     hints := .opaque
     safety := .safe
   })
@@ -1520,3 +1520,48 @@ bad_consts #[`DupInd]
 /-- An inductive with two constructors with the same name -/
 bad_consts #[`DupInd2]
   renaming #[(`DupInd2, `DupConCon), (`DupInd2.mk1, `dup_ind_con_con.mk), (`DupInd2.mk2, `dup_ind_con_con.mk)]
+
+/-! ## Safety
+
+Unsafe and partial declarations can't be used in theorems.
+
+Kernels are permitted to automatically reject or decline whenever they see an unsafe or partial declaration (nanoda does this).
+That's reasonable because, if partial or unsafe declarations are unused, `lean4export` will just strip them out.
+Other kernels simply ignore unsafe and partial definitions, so any later use of them becomes an undefined constant.
+-/
+
+unsafe def unsafeLoop : False := unsafeLoop
+
+/-- Unsafe definitions cannot be used in theorems -/
+bad_decl (.thmDecl {
+  name := `falseFromUnsafe
+  levelParams := []
+  type := Lean.mkConst ``False
+  value := Lean.mkConst `unsafeLoop
+})
+
+/- We can't write this:
+
+```
+partial def partialLoop : False := partialLoop
+```
+
+The reason is that the Lean's *elaborator* only allows `partial def` to be an inhabited type.
+The kernel doesn't care about this in the.
+-/
+run_meta Lean.addDecl (.mutualDefnDecl [{
+  name := `partialLoop
+  levelParams := []
+  type := Lean.mkConst ``False
+  value := Lean.mkConst `partialLoop
+  hints := .opaque
+  safety := .partial
+}])
+
+/-- Partial definitions cannot be used in theorems -/
+bad_decl (.thmDecl {
+  name := `falseFromPartial
+  levelParams := []
+  type := Lean.mkConst ``False
+  value := Lean.mkConst `partialLoop
+})

--- a/tutorial/Tutorial.lean
+++ b/tutorial/Tutorial.lean
@@ -1547,7 +1547,7 @@ partial def partialLoop : False := partialLoop
 ```
 
 The reason is that the Lean's *elaborator* only allows `partial def` to be an inhabited type.
-The kernel doesn't care about this in the.
+The kernel does not ensure that `.partial` types are inhabited.
 -/
 run_meta Lean.addDecl (.mutualDefnDecl [{
   name := `partialLoop

--- a/tutorial/Tutorial/Export.lean
+++ b/tutorial/Tutorial/Export.lean
@@ -49,7 +49,7 @@ def M.runSmall (env : Environment) (act : M α) : IO α :=
 def exportDeclsFromEnv (env : Lean.Environment) (constants : Array Name)
     (renamings : NameMap Name := {}) : IO Unit := do
   M.runSmall env do
-    initStateCached env
+    initStateCached env ["--export-unsafe"]
     dumpMetadata
     -- First dump all names in the range of the renamings map
     for (_, target) in renamings.toList do


### PR DESCRIPTION
Check that kernels correctly reject (nanoda) OR ignore (lean's official replay mechanism) unsafe and partial declarations. Requires actually exporting unsafe declarations in the first place.