### PR TITLE
checkers: bump mathgraph to V3 candidate

### DIFF
--- a/checkers/mathgraph.yaml
+++ b/checkers/mathgraph.yaml
@@ -20,7 +20,7 @@ description: |
   Developed by [Metalogic Labs](https://mathgraph.org/).
 url: https://github.com/metalogiclabs/mathgraph-lean-kernel
 ref: mathgraph
-rev: 3d7585c21242f29fdaa48ae9a16e16c6afe42238
+rev: 801cb6d918d0e383e4c6a3c6017ef945d42a0698
 build: |
   cat > config.json <<__END__
    {


### PR DESCRIPTION
bumps mathgraph to the v3 candidate.

narrow change from differential/performance testing around equal-hint unfolding for (1,3), (1,4) and (1,6).

local qualification was 205/205 with 0 mismatches. paired mathlib wall time was ~4.5% better, but the point of this PR is to get the actual arena instruction count.