### PR TITLE
Add definition self-reference rejection test

### DIFF
--- a/tests/definition-self-reference.ndjson
+++ b/tests/definition-self-reference.ndjson
@@ -1,0 +1,6 @@
+{"meta":{"exporter":{"name":"lean4export","version":"3.1.0"},"format":{"version":"3.1.0"},"lean":{"githash":"f72c35b3f637c8c6571d353742168ab66cc22c00","version":"4.29.1"}}}
+{"in":1,"str":{"pre":0,"str":"cutoffSelf"}}
+{"il":1,"succ":0}
+{"ie":0,"sort":1}
+{"const":{"name":1,"us":[]},"ie":1}
+{"def":{"all":[1],"hints":"opaque","levelParams":[],"name":1,"safety":"safe","type":0,"value":1}}

--- a/tests/definition-self-reference.yaml
+++ b/tests/definition-self-reference.yaml
@@ -1,0 +1,12 @@
+description: |
+  Reject an ordinary definition whose value refers to the definition itself.
+
+  The export is equivalent to `def cutoffSelf : Sort 1 := cutoffSelf`. The
+  declaration under validation must not be available while its value is being
+  checked. Otherwise its claimed type can be used as evidence that its circular
+  value is well-typed.
+
+  This case exposed a disagreement in Kiota:
+  <https://github.com/sankalpsthakur/kiota/issues/5>.
+file: tests/definition-self-reference.ndjson
+outcome: reject


### PR DESCRIPTION
## Summary

- add a hand-crafted static export containing an ordinary definition that refers to itself
- mark the expected outcome as `reject`
- link the Kiota checker disagreement exposed by the test

The declaration is equivalent to:

```lean
def cutoffSelf : Sort 1 := cutoffSelf
```

The declaration under validation must not be visible while its value is checked; otherwise its claimed type can be used to validate its circular value.

Kiota tracking issue: https://github.com/sankalpsthakur/kiota/issues/5

Investigation and cross-validation evidence: https://github.com/phiferd/lean-assurance-lab/blob/829c72e/docs/investigations/NANODA_ENV_CUTOFF_SURVIVOR.md

## Validation

```console
../../.venv-arena/bin/python ./lka.py build-test definition-self-reference
```

Result: `1 succeeded, 0 failed`.

Arena runner outcomes:

| Checker | Outcome |
| --- | --- |
| official | rejects as expected |
| lean4lean | rejects as expected |
| nanoda | rejects as expected |
| kiota | accepts, exposing the tracked disagreement |
