### PR TITLE
feat: add lean-lang.org plausible snippet

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,11 @@
     <title>{% block title %}Lean Kernel Arena{% endblock %}</title>
     <link rel="stylesheet" href="https://unpkg.com/chota@latest">
     <link rel="stylesheet" href="{% block static_path %}{% endblock %}static/style.css">
+    <script async src="https://plausible.io/js/pa-RTua_4FfKHhfAvAc3liZd.js"></script>
+    <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+    </script>
     <style>
         {% block style %}{% endblock %}
     </style>


### PR DESCRIPTION
This PR adds the lean-lang.org Plausible website analytics snippet to the Kernel Arena. The snippet enables tracking over overall site usage trends via the lean-lang.org Plausible dashboard, but does not track or store any persistent data, personal identifiers, nor does it use cookies. More info [here](https://plausible.io/privacy-focused-web-analytics). 