### PR TITLE
Add imax right-successor corner cases

### DIFF
--- a/tests/corner-cases/imax-right-successor.lean
+++ b/tests/corner-cases/imax-right-successor.lean
@@ -1,0 +1,27 @@
+import Lean
+open Lean Elab Command
+
+/-
+The semantic level equation `imax u (v + 1) = max u (v + 1)` follows because
+the right operand is nonzero. The official kernel does not normalize this
+hand-crafted declaration in that form, while other checkers may do so.
+-/
+
+set_option debug.skipKernelTC true in
+run_cmd liftTermElabM do
+  addDecl <| .defnDecl {
+    name := `imaxRightOne
+    levelParams := [`u]
+    type := .sort (.succ (.max (.param `u) (.succ 0)))
+    value := .sort (.imax (.param `u) (.succ 0))
+    hints := .opaque
+    safety := .safe
+  }
+  addDecl <| .defnDecl {
+    name := `imaxRightSucc
+    levelParams := [`u, `v]
+    type := .sort (.succ (.max (.param `u) (.succ (.param `v))))
+    value := .sort (.imax (.param `u) (.succ (.param `v)))
+    hints := .opaque
+    safety := .safe
+  }

--- a/tests/corner-cases/imax-right-successor.yaml
+++ b/tests/corner-cases/imax-right-successor.yaml
@@ -1,0 +1,9 @@
+description: |
+  Universe-level normalization corner cases. The declarations use `imax u 1`
+  and `imax u (v + 1)` where their declared types use the corresponding
+  `max` levels. A checker may reject these hand-crafted exports using a more
+  conservative normalization, or accept them by recognizing that the right
+  operand is nonzero.
+leanfile: tests/corner-cases/imax-right-successor.lean
+export-decls: ["imaxRightOne", "imaxRightSucc"]
+outcome: either


### PR DESCRIPTION
Closes #175.

Adds the two requested universe-normalization corner cases:

- `imax u 1` versus `max u 1`
- `imax u (v + 1)` versus `max u (v + 1)`

They are a single `corner-cases/` export with `outcome: either`: a checker may
reject the hand-crafted declarations conservatively, or accept them using more
complete level normalization. The official checker rejects the export and
Arena records that result as permitted rather than scoring it as a failure.

Validation:

- `.venv-arena/bin/python ./lka.py build-test corner-cases/imax-right-successor`
- `.venv-arena/bin/python ./lka.py run --checker official --test corner-cases/imax-right-successor`
