### PR TITLE
checkers: bump kiota to 2d2a9fa

### DIFF
--- a/checkers/kiota.yaml
+++ b/checkers/kiota.yaml
@@ -6,6 +6,6 @@ description: |
 version: "0.1.0"
 url: https://github.com/sankalpsthakur/kiota
 ref: main
-rev: 58e8636cfb51cf9c3bf3de7455a0e3c6ab68e87a
+rev: 2d2a9fa31cba31abdd49543c3bb667591207577e
 build: cargo build --release
 run: timeout 3600s ./target/release/kiota "$IN"


### PR DESCRIPTION
Pins kiota to the consolidated `main` release at [`2d2a9fa`](https://github.com/sankalpsthakur/kiota/commit/2d2a9fa31cba31abdd49543c3bb667591207577e).

Since the current `58e8636` pin:

- removes declaration-name proof shortcuts and keeps full theorem-value checking
- derives recursor/large-elimination invariants and validates numeral shortcuts
- fixes Acc, projection, nested-recursion, constructor-universe, and defeq gaps
- bounds `Nat.rec`/interner growth, resets generation-sensitive caches safely, and drops deep spines iteratively

Kiota verification: 81 lib + 68 export tests pass under default and `KIOTA_NBE=1`; CI is green. Latest Arena sweep on this line: 0 false accepts / 0 false rejects / 0 declines.

This PR changes only the immutable `rev`; timeout and corpus policy stay unchanged.

### AI/LLM disclosure

AI coding tools assisted with code and text. I reviewed the complete change and ran the reported tests.