### PR TITLE
checkers: bump mathgraph

### DIFF
--- a/checkers/mathgraph.yaml
+++ b/checkers/mathgraph.yaml
@@ -20,7 +20,7 @@ description: |
   Developed by [Metalogic Labs](https://mathgraph.org/).
 url: https://github.com/metalogiclabs/mathgraph-lean-kernel
 ref: mathgraph
-rev: 2de1895a52d21ad266b77002defe3e6bc69bbcfd
+rev: a8e6886e417ce25320bee6e9a990fa72e44a7320
 build: |
   cat > config.json <<__END__
    {

--- a/checkers/mathgraph.yaml
+++ b/checkers/mathgraph.yaml
@@ -20,7 +20,7 @@ description: |
   Developed by [Metalogic Labs](https://mathgraph.org/).
 url: https://github.com/metalogiclabs/mathgraph-lean-kernel
 ref: mathgraph
-rev: a8e6886e417ce25320bee6e9a990fa72e44a7320
+rev: 08ddb26718c86213262943ca19ae8cf1b03fa922
 build: |
   cat > config.json <<__END__
    {

--- a/checkers/mathgraph.yaml
+++ b/checkers/mathgraph.yaml
@@ -18,9 +18,10 @@ description: |
   constraint → new residual
 
   Developed by [Metalogic Labs](https://mathgraph.org/).
+version: "dulce-de-leche"
 url: https://github.com/metalogiclabs/mathgraph-lean-kernel
-ref: mathgraph
-rev: 08ddb26718c86213262943ca19ae8cf1b03fa922
+ref: dulce-de-leche
+rev: d6a73279e6765e637f9741180cefbd7ef957d8e5
 build: |
   cat > config.json <<__END__
    {


### PR DESCRIPTION
Updates MathGraph to dulce-de-leche.

Fixes the con-leche completeness failure caused by deep environment keying